### PR TITLE
refactor(http): 移除 #[serde(untagged)]，改为自定义反序列化

### DIFF
--- a/application-rs/.gitignore
+++ b/application-rs/.gitignore
@@ -2,3 +2,4 @@
 /target
 config.toml
 /.idea
+.sisyphus

--- a/application-rs/application-util/src/http.rs
+++ b/application-rs/application-util/src/http.rs
@@ -1,57 +1,19 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::LazyLock;
 use std::time::Duration;
 
 use reqwest::{Client, Request};
-use serde::{Deserialize, Deserializer, de, de::DeserializeOwned};
+use serde::{Deserialize, Deserializer, de};
 use serde_json::Value;
 use tracing::{info, warn};
 
 use application_kernel::result::{Error, Result};
 
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct HttpResponse<S, E> {
     pub status: u16,
-    pub headers: HashMap<String, String>,
-    pub body: String,
     pub duration: f32,
     pub inner: ResponseVariant<S, E>,
-}
-
-impl<'de, S, E> Deserialize<'de> for HttpResponse<S, E>
-where
-    S: Debug + DeserializeOwned,
-    E: Debug + DeserializeOwned,
-{
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct RawHttpResponse<S, E> {
-            status: u16,
-            headers: HashMap<String, String>,
-            body: String,
-            duration: f32,
-            inner: Value,
-            #[serde(skip)]
-            _marker: std::marker::PhantomData<(S, E)>,
-        }
-
-        let raw = RawHttpResponse::<S, E>::deserialize(deserializer)?;
-        let inner = serde_json::from_value::<ResponseVariant<S, E>>(raw.inner)
-            .map_err(de::Error::custom)?;
-
-        Ok(Self {
-            status: raw.status,
-            headers: raw.headers,
-            body: raw.body,
-            duration: raw.duration,
-            inner,
-        })
-    }
 }
 
 #[derive(Debug)]
@@ -130,50 +92,48 @@ static G_CLIENT: LazyLock<Client> = LazyLock::new(|| {
         .expect("HTTP 客户端初始化失败")
 });
 
-pub async fn request<S, E>(request: Request) -> Result<HttpResponse<S, E>>
+pub async fn request<S, E>(req: Request) -> Result<HttpResponse<S, E>>
 where
     S: Debug + for<'de> Deserialize<'de>,
     E: Debug + for<'de> Deserialize<'de>,
 {
-    info!("请求第三方服务接口 {:?}", request);
+    info!("请求第三方服务接口 {:?}", req);
 
     let started_at = std::time::Instant::now();
-    let response = G_CLIENT.execute(request).await.map_err(|e| {
+    let response = G_CLIENT.execute(req).await.map_err(|e| {
         warn!("请求第三方服务接口失败 {:?}", e);
         Error::ThirdHttpRequest(None)
     })?;
 
     let status = response.status().as_u16();
-    let headers = response
-        .headers()
-        .iter()
-        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
-        .collect::<HashMap<String, String>>();
 
     let body = response.text().await.map_err(|e| {
         warn!("接收第三方服务接口响应失败 {:?}", e);
         Error::ThirdHttpResponse(None)
     })?;
 
-    info!(
-        "请求第三方服务接口结果： headers: {:?}, body: {:?}",
-        &headers, &body
-    );
+    info!("请求第三方服务接口结果： body: {:?}", &body);
 
     let inner = serde_json::from_str::<ResponseVariant<S, E>>(&body)
         .map_err(|_| Error::ThirdHttpResponseParse(None))?;
 
-    if !inner.is_success() {
-        return Err(Error::ThirdHttpResponseResult(None));
-    }
-
     Ok(HttpResponse {
         status,
-        headers,
-        body,
         duration: started_at.elapsed().as_secs_f32(),
         inner,
     })
+}
+
+pub async fn request_success<S, E>(req: Request) -> Result<S>
+where
+    S: Debug + for<'de> Deserialize<'de>,
+    E: Debug + for<'de> Deserialize<'de>,
+{
+    let response = request::<S, E>(req).await?;
+    response
+        .inner
+        .into_success()
+        .ok_or(Error::ThirdHttpResponseResult(None))
 }
 
 pub fn map_request_err(e: Error, platform: &str) -> Error {

--- a/application-rs/application-util/src/http.rs
+++ b/application-rs/application-util/src/http.rs
@@ -4,7 +4,7 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use reqwest::{Client, Request};
-use serde::{de, de::DeserializeOwned, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de, de::DeserializeOwned};
 use serde_json::Value;
 use tracing::{info, warn};
 

--- a/application-rs/application-util/src/http.rs
+++ b/application-rs/application-util/src/http.rs
@@ -4,13 +4,14 @@ use std::sync::LazyLock;
 use std::time::Duration;
 
 use reqwest::{Client, Request};
-use serde::Deserialize;
+use serde::{de, de::DeserializeOwned, Deserialize, Deserializer};
+use serde_json::Value;
 use tracing::{info, warn};
 
 use application_kernel::result::{Error, Result};
 
 #[allow(dead_code)]
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub struct HttpResponse<S, E> {
     pub status: u16,
     pub headers: HashMap<String, String>,
@@ -19,23 +20,47 @@ pub struct HttpResponse<S, E> {
     pub inner: ResponseVariant<S, E>,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
+impl<'de, S, E> Deserialize<'de> for HttpResponse<S, E>
+where
+    S: Debug + DeserializeOwned,
+    E: Debug + DeserializeOwned,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawHttpResponse<S, E> {
+            status: u16,
+            headers: HashMap<String, String>,
+            body: String,
+            duration: f32,
+            inner: Value,
+            #[serde(skip)]
+            _marker: std::marker::PhantomData<(S, E)>,
+        }
+
+        let raw = RawHttpResponse::<S, E>::deserialize(deserializer)?;
+        let inner = serde_json::from_value::<ResponseVariant<S, E>>(raw.inner)
+            .map_err(de::Error::custom)?;
+
+        Ok(Self {
+            status: raw.status,
+            headers: raw.headers,
+            body: raw.body,
+            duration: raw.duration,
+            inner,
+        })
+    }
+}
+
+#[derive(Debug)]
 pub enum ResponseVariant<S, E> {
     Success(S),
     Error(E),
 }
 
 impl<S, E> ResponseVariant<S, E> {
-    pub fn parse(body: &str) -> Result<Self>
-    where
-        S: Debug + for<'de> Deserialize<'de>,
-        E: Debug + for<'de> Deserialize<'de>,
-    {
-        serde_json::from_str::<ResponseVariant<S, E>>(body)
-            .map_err(|_| Error::ThirdHttpResponseParse(None))
-    }
-
     pub fn is_success(&self) -> bool {
         matches!(self, ResponseVariant::Success(_))
     }
@@ -55,13 +80,54 @@ impl<S, E> ResponseVariant<S, E> {
     }
 }
 
+impl<'de, S, E> Deserialize<'de> for ResponseVariant<S, E>
+where
+    S: Debug + for<'d> Deserialize<'d>,
+    E: Debug + for<'d> Deserialize<'d>,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        // 判别逻辑 1：errcode == 0 → Success（微信）
+        if let Some(errcode) = value.get("errcode").and_then(|errcode| errcode.as_u64()) {
+            return if errcode == 0 {
+                serde_json::from_value::<S>(value)
+                    .map(ResponseVariant::Success)
+                    .map_err(de::Error::custom)
+            } else {
+                serde_json::from_value::<E>(value)
+                    .map(ResponseVariant::Error)
+                    .map_err(de::Error::custom)
+            };
+        }
+
+        // 判别逻辑 2：error 存在且非空 → Error（华为）
+        if let Some(error) = value.get("error").and_then(|error| error.as_str())
+            && !error.is_empty()
+        {
+            return serde_json::from_value::<E>(value)
+                .map(ResponseVariant::Error)
+                .map_err(de::Error::custom);
+        }
+
+        // 兜底：先尝试 Success，失败则尝试 Error
+        serde_json::from_value::<S>(value.clone())
+            .map(ResponseVariant::Success)
+            .or_else(|_| serde_json::from_value::<E>(value).map(ResponseVariant::Error))
+            .map_err(de::Error::custom)
+    }
+}
+
 static G_CLIENT: LazyLock<Client> = LazyLock::new(|| {
     Client::builder()
         .user_agent("yansongda/application-rs")
         .connect_timeout(Duration::from_secs(1))
         .timeout(Duration::from_secs(3))
         .build()
-        .unwrap()
+        .expect("HTTP 客户端初始化失败")
 });
 
 pub async fn request<S, E>(request: Request) -> Result<HttpResponse<S, E>>
@@ -94,20 +160,20 @@ where
         &headers, &body
     );
 
-    let result = HttpResponse {
-        status,
-        headers,
-        body: body.clone(),
-        duration: started_at.elapsed().as_secs_f32(),
-        inner: serde_json::from_str::<ResponseVariant<S, E>>(&body)
-            .map_err(|_| Error::ThirdHttpResponseParse(None))?,
-    };
+    let inner = serde_json::from_str::<ResponseVariant<S, E>>(&body)
+        .map_err(|_| Error::ThirdHttpResponseParse(None))?;
 
-    if !result.inner.is_success() {
+    if !inner.is_success() {
         return Err(Error::ThirdHttpResponseResult(None));
     }
 
-    Ok(result)
+    Ok(HttpResponse {
+        status,
+        headers,
+        body,
+        duration: started_at.elapsed().as_secs_f32(),
+        inner,
+    })
 }
 
 pub fn map_request_err(e: Error, platform: &str) -> Error {

--- a/application-rs/application-util/src/http.rs
+++ b/application-rs/application-util/src/http.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use reqwest::{Client, Request};
 use serde::Deserialize;
-use tracing::{info, warn};
+use tracing::{error, info};
 
 use application_kernel::result::{Error, Result};
 
@@ -32,7 +32,7 @@ where
 
     let started_at = std::time::Instant::now();
     let response = G_CLIENT.execute(req).await.map_err(|e| {
-        warn!("请求第三方服务接口失败 {:?}", e);
+        error!("请求第三方服务接口失败 {:?}", e);
         Error::ThirdHttpRequest(None)
     })?;
 
@@ -44,7 +44,7 @@ where
         .collect::<HashMap<String, String>>();
 
     let body = response.text().await.map_err(|e| {
-        warn!("接收第三方服务接口响应失败 {:?}", e);
+        error!("接收第三方服务接口响应失败 {:?}", e);
         Error::ThirdHttpResponse(None)
     })?;
 

--- a/application-rs/application-util/src/http.rs
+++ b/application-rs/application-util/src/http.rs
@@ -1,87 +1,18 @@
 use std::collections::HashMap;
-use std::fmt::Debug;
 use std::sync::LazyLock;
 use std::time::Duration;
 
 use reqwest::{Client, Request};
-use serde::{Deserialize, Deserializer, de};
-use serde_json::Value;
+use serde::Deserialize;
 use tracing::{info, warn};
 
 use application_kernel::result::{Error, Result};
 
 #[derive(Debug)]
-pub struct HttpResponse<S, E> {
+pub struct HttpResponse<T> {
     pub status: u16,
     pub duration: f32,
-    pub inner: ResponseVariant<S, E>,
-}
-
-#[derive(Debug)]
-pub enum ResponseVariant<S, E> {
-    Success(S),
-    Error(E),
-}
-
-impl<S, E> ResponseVariant<S, E> {
-    pub fn is_success(&self) -> bool {
-        matches!(self, ResponseVariant::Success(_))
-    }
-
-    pub fn into_success(self) -> Option<S> {
-        match self {
-            ResponseVariant::Success(success) => Some(success),
-            ResponseVariant::Error(_) => None,
-        }
-    }
-
-    pub fn into_error(self) -> Option<E> {
-        match self {
-            ResponseVariant::Error(error) => Some(error),
-            ResponseVariant::Success(_) => None,
-        }
-    }
-}
-
-impl<'de, S, E> Deserialize<'de> for ResponseVariant<S, E>
-where
-    S: Debug + for<'d> Deserialize<'d>,
-    E: Debug + for<'d> Deserialize<'d>,
-{
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = Value::deserialize(deserializer)?;
-
-        // 判别逻辑 1：errcode == 0 → Success（微信）
-        if let Some(errcode) = value.get("errcode").and_then(|errcode| errcode.as_u64()) {
-            return if errcode == 0 {
-                serde_json::from_value::<S>(value)
-                    .map(ResponseVariant::Success)
-                    .map_err(de::Error::custom)
-            } else {
-                serde_json::from_value::<E>(value)
-                    .map(ResponseVariant::Error)
-                    .map_err(de::Error::custom)
-            };
-        }
-
-        // 判别逻辑 2：error 存在且非空 → Error（华为）
-        if let Some(error) = value.get("error").and_then(|error| error.as_str())
-            && !error.is_empty()
-        {
-            return serde_json::from_value::<E>(value)
-                .map(ResponseVariant::Error)
-                .map_err(de::Error::custom);
-        }
-
-        // 兜底：先尝试 Success，失败则尝试 Error
-        serde_json::from_value::<S>(value.clone())
-            .map(ResponseVariant::Success)
-            .or_else(|_| serde_json::from_value::<E>(value).map(ResponseVariant::Error))
-            .map_err(de::Error::custom)
-    }
+    pub inner: T,
 }
 
 static G_CLIENT: LazyLock<Client> = LazyLock::new(|| {
@@ -93,10 +24,9 @@ static G_CLIENT: LazyLock<Client> = LazyLock::new(|| {
         .expect("HTTP 客户端初始化失败")
 });
 
-pub async fn request<S, E>(req: Request) -> Result<HttpResponse<S, E>>
+pub async fn request<T>(req: Request) -> Result<HttpResponse<T>>
 where
-    S: Debug + for<'de> Deserialize<'de>,
-    E: Debug + for<'de> Deserialize<'de>,
+    T: for<'de> Deserialize<'de>,
 {
     info!("请求第三方服务接口 {:?}", req);
 
@@ -123,34 +53,12 @@ where
         &headers, &body
     );
 
-    let inner = serde_json::from_str::<ResponseVariant<S, E>>(&body)
-        .map_err(|_| Error::ThirdHttpResponseParse(None))?;
+    let inner =
+        serde_json::from_str::<T>(&body).map_err(|_| Error::ThirdHttpResponseParse(None))?;
 
     Ok(HttpResponse {
         status,
         duration: started_at.elapsed().as_secs_f32(),
         inner,
     })
-}
-
-pub fn map_request_err(e: Error, platform: &str) -> Error {
-    match e {
-        Error::ThirdHttpRequest(_) => Error::ThirdHttpRequest(Some(format!(
-            "第三方错误: {} API 请求出错，请联系管理员",
-            platform
-        ))),
-        Error::ThirdHttpResponse(_) => Error::ThirdHttpResponse(Some(format!(
-            "第三方错误: {} API 响应接收出错，请联系管理员",
-            platform
-        ))),
-        Error::ThirdHttpResponseParse(_) => Error::ThirdHttpResponseParse(Some(format!(
-            "第三方错误: {} API 响应解析出错，请联系管理员",
-            platform
-        ))),
-        Error::ThirdHttpResponseResult(_) => Error::ThirdHttpResponseResult(Some(format!(
-            "第三方错误: {} API 响应业务结果出错，请联系管理员",
-            platform
-        ))),
-        _ => Error::ThirdHttpRequest(None),
-    }
 }

--- a/application-rs/application-util/src/http.rs
+++ b/application-rs/application-util/src/http.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -106,13 +107,21 @@ where
     })?;
 
     let status = response.status().as_u16();
+    let headers = response
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect::<HashMap<String, String>>();
 
     let body = response.text().await.map_err(|e| {
         warn!("接收第三方服务接口响应失败 {:?}", e);
         Error::ThirdHttpResponse(None)
     })?;
 
-    info!("请求第三方服务接口结果： body: {:?}", &body);
+    info!(
+        "请求第三方服务接口结果： headers: {:?}, body: {:?}",
+        &headers, &body
+    );
 
     let inner = serde_json::from_str::<ResponseVariant<S, E>>(&body)
         .map_err(|_| Error::ThirdHttpResponseParse(None))?;
@@ -122,18 +131,6 @@ where
         duration: started_at.elapsed().as_secs_f32(),
         inner,
     })
-}
-
-pub async fn request_success<S, E>(req: Request) -> Result<S>
-where
-    S: Debug + for<'de> Deserialize<'de>,
-    E: Debug + for<'de> Deserialize<'de>,
-{
-    let response = request::<S, E>(req).await?;
-    response
-        .inner
-        .into_success()
-        .ok_or(Error::ThirdHttpResponseResult(None))
 }
 
 pub fn map_request_err(e: Error, platform: &str) -> Error {

--- a/application-rs/application-util/src/http.rs
+++ b/application-rs/application-util/src/http.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use reqwest::{Client, Request};
 use serde::Deserialize;
-use tracing::{error, info};
+use tracing::{info, warn};
 
 use application_kernel::result::{Error, Result};
 
@@ -32,7 +32,7 @@ where
 
     let started_at = std::time::Instant::now();
     let response = G_CLIENT.execute(req).await.map_err(|e| {
-        error!("请求第三方服务接口失败 {:?}", e);
+        warn!("请求第三方服务接口失败 {:?}", e);
         Error::ThirdHttpRequest(None)
     })?;
 
@@ -44,7 +44,7 @@ where
         .collect::<HashMap<String, String>>();
 
     let body = response.text().await.map_err(|e| {
-        error!("接收第三方服务接口响应失败 {:?}", e);
+        warn!("接收第三方服务接口响应失败 {:?}", e);
         Error::ThirdHttpResponse(None)
     })?;
 

--- a/application-rs/application-util/src/huawei.rs
+++ b/application-rs/application-util/src/huawei.rs
@@ -36,15 +36,15 @@ impl<'de> Deserialize<'de> for TokenResponse {
         let value = Value::deserialize(deserializer)?;
 
         // 检查 error 字段（数字类型）
-        if let Some(error) = value.get("error").and_then(|e| e.as_i64()) {
-            if error != 0 {
-                let err: TokenResponseError =
-                    serde_json::from_value(value).map_err(de::Error::custom)?;
-                return Err(de::Error::custom(format!(
-                    "第三方错误: 华为 API 响应业务结果出错，请联系管理员: {}",
-                    err.error_description
-                )));
-            }
+        if let Some(error) = value.get("error").and_then(|e| e.as_i64())
+            && error != 0
+        {
+            let err: TokenResponseError =
+                serde_json::from_value(value).map_err(de::Error::custom)?;
+            return Err(de::Error::custom(format!(
+                "第三方错误: 华为 API 响应业务结果出错，请联系管理员: {}",
+                err.error_description
+            )));
         }
 
         serde_json::from_value::<RawTokenResponse>(value)

--- a/application-rs/application-util/src/huawei.rs
+++ b/application-rs/application-util/src/huawei.rs
@@ -45,16 +45,15 @@ pub async fn token(code: &str, app_id: &str, client_secret: &str) -> Result<Toke
     )
     .form(&form);
 
-    let response = http::request_success::<TokenResponse, TokenResponseError>(
-        builder.build().map_err(|e| {
-            warn!("请求构建失败: {:?}", e);
-            Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
-        })?,
-    )
+    http::request::<TokenResponse, TokenResponseError>(builder.build().map_err(|e| {
+        warn!("请求构建失败: {:?}", e);
+        Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
+    })?)
     .await
-    .map_err(|e| map_request_err(e, "华为"))?;
-
-    Ok(response)
+    .map_err(|e| map_request_err(e, "华为"))?
+    .inner
+    .into_success()
+    .ok_or(Error::ThirdHttpResponseResult(None))
 }
 
 #[allow(dead_code)]
@@ -89,14 +88,13 @@ pub async fn token_info(access_token: &str) -> Result<TokenInfoResponse> {
     )
         .form(&form);
 
-    let response = http::request_success::<TokenInfoResponse, TokenInfoResponseError>(
-        builder.build().map_err(|e| {
-            warn!("请求构建失败: {:?}", e);
-            Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
-        })?,
-    )
+    http::request::<TokenInfoResponse, TokenInfoResponseError>(builder.build().map_err(|e| {
+        warn!("请求构建失败: {:?}", e);
+        Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
+    })?)
     .await
-    .map_err(|e| map_request_err(e, "华为"))?;
-
-    Ok(response)
+    .map_err(|e| map_request_err(e, "华为"))?
+    .inner
+    .into_success()
+    .ok_or(Error::ThirdHttpResponseResult(None))
 }

--- a/application-rs/application-util/src/huawei.rs
+++ b/application-rs/application-util/src/huawei.rs
@@ -2,8 +2,10 @@ use reqwest::{Client, Method, Request, RequestBuilder, Url};
 
 use crate::http;
 use crate::http::map_request_err;
+use application_kernel::result::Error;
 use application_kernel::result::Result;
 use serde::Deserialize;
+use tracing::warn;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
@@ -35,16 +37,24 @@ pub async fn token(code: &str, app_id: &str, client_secret: &str) -> Result<Toke
         Client::new(),
         Request::new(
             Method::POST,
-            Url::parse("https://oauth-login.cloud.huawei.com/oauth2/v3/token").unwrap(),
+            Url::parse("https://oauth-login.cloud.huawei.com/oauth2/v3/token").map_err(|e| {
+                warn!("URL 解析失败: {:?}", e);
+                Error::ThirdHttpRequest(Some("URL 格式无效".to_string()))
+            })?,
         ),
     )
     .form(&form);
 
-    let response = http::request::<TokenResponse, TokenResponseError>(builder.build().unwrap())
-        .await
-        .map_err(|e| map_request_err(e, "华为"))?;
+    let response = http::request_success::<TokenResponse, TokenResponseError>(
+        builder.build().map_err(|e| {
+            warn!("请求构建失败: {:?}", e);
+            Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
+        })?,
+    )
+    .await
+    .map_err(|e| map_request_err(e, "华为"))?;
 
-    Ok(response.inner.into_success().unwrap())
+    Ok(response)
 }
 
 #[allow(dead_code)]
@@ -71,15 +81,22 @@ pub async fn token_info(access_token: &str) -> Result<TokenInfoResponse> {
         Client::new(),
         Request::new(
             Method::POST,
-            Url::parse("https://oauth-api.cloud.huawei.com/rest.php?nsp_fmt=JSON&nsp_svc=huawei.oauth2.user.getTokenInfo").unwrap()
+            Url::parse("https://oauth-api.cloud.huawei.com/rest.php?nsp_fmt=JSON&nsp_svc=huawei.oauth2.user.getTokenInfo").map_err(|e| {
+                warn!("URL 解析失败: {:?}", e);
+                Error::ThirdHttpRequest(Some("URL 格式无效".to_string()))
+            })?,
         ),
     )
         .form(&form);
 
-    let response =
-        http::request::<TokenInfoResponse, TokenInfoResponseError>(builder.build().unwrap())
-            .await
-            .map_err(|e| map_request_err(e, "华为"))?;
+    let response = http::request_success::<TokenInfoResponse, TokenInfoResponseError>(
+        builder.build().map_err(|e| {
+            warn!("请求构建失败: {:?}", e);
+            Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
+        })?,
+    )
+    .await
+    .map_err(|e| map_request_err(e, "华为"))?;
 
-    Ok(response.inner.into_success().unwrap())
+    Ok(response)
 }

--- a/application-rs/application-util/src/huawei.rs
+++ b/application-rs/application-util/src/huawei.rs
@@ -5,7 +5,7 @@ use application_kernel::result::Error;
 use application_kernel::result::Result;
 use serde::{Deserialize, Deserializer, de};
 use serde_json::Value;
-use tracing::warn;
+use tracing::error;
 
 #[allow(dead_code)]
 #[derive(Debug, Clone)]
@@ -35,15 +35,16 @@ impl<'de> Deserialize<'de> for TokenResponse {
     {
         let value = Value::deserialize(deserializer)?;
 
-        if let Some(error) = value.get("error").and_then(|e| e.as_str())
-            && !error.is_empty()
-        {
-            let err: TokenResponseError =
-                serde_json::from_value(value).map_err(de::Error::custom)?;
-            return Err(de::Error::custom(format!(
-                "第三方错误: 华为 API 响应业务结果出错，请联系管理员: {}",
-                err.error_description
-            )));
+        // 检查 error 字段（数字类型）
+        if let Some(error) = value.get("error").and_then(|e| e.as_i64()) {
+            if error != 0 {
+                let err: TokenResponseError =
+                    serde_json::from_value(value).map_err(de::Error::custom)?;
+                return Err(de::Error::custom(format!(
+                    "第三方错误: 华为 API 响应业务结果出错，请联系管理员: {}",
+                    err.error_description
+                )));
+            }
         }
 
         serde_json::from_value::<RawTokenResponse>(value)
@@ -62,7 +63,7 @@ impl<'de> Deserialize<'de> for TokenResponse {
 #[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct TokenResponseError {
-    pub error: String,
+    pub error: i64,
     pub error_description: String,
 }
 
@@ -79,7 +80,7 @@ pub async fn token(code: &str, app_id: &str, client_secret: &str) -> Result<Toke
         Request::new(
             Method::POST,
             Url::parse("https://oauth-login.cloud.huawei.com/oauth2/v3/token").map_err(|e| {
-                warn!("URL 解析失败: {:?}", e);
+                error!("URL 解析失败: {:?}", e);
                 Error::ThirdHttpRequest(Some("URL 格式无效".to_string()))
             })?,
         ),
@@ -87,7 +88,7 @@ pub async fn token(code: &str, app_id: &str, client_secret: &str) -> Result<Toke
     .form(&form);
 
     http::request::<TokenResponse>(builder.build().map_err(|e| {
-        warn!("请求构建失败: {:?}", e);
+        error!("请求构建失败: {:?}", e);
         Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
     })?)
     .await
@@ -158,7 +159,7 @@ pub async fn token_info(access_token: &str) -> Result<TokenInfoResponse> {
         Request::new(
             Method::POST,
             Url::parse("https://oauth-api.cloud.huawei.com/rest.php?nsp_fmt=JSON&nsp_svc=huawei.oauth2.user.getTokenInfo").map_err(|e| {
-                warn!("URL 解析失败: {:?}", e);
+                error!("URL 解析失败: {:?}", e);
                 Error::ThirdHttpRequest(Some("URL 格式无效".to_string()))
             })?,
         ),
@@ -166,7 +167,7 @@ pub async fn token_info(access_token: &str) -> Result<TokenInfoResponse> {
         .form(&form);
 
     http::request::<TokenInfoResponse>(builder.build().map_err(|e| {
-        warn!("请求构建失败: {:?}", e);
+        error!("请求构建失败: {:?}", e);
         Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
     })?)
     .await
@@ -200,7 +201,7 @@ mod tests {
     #[test]
     fn deserialize_token_response_error() {
         let value = serde_json::json!({
-            "error": "invalid_grant",
+            "error": 10001,
             "error_description": "bad code"
         });
 

--- a/application-rs/application-util/src/huawei.rs
+++ b/application-rs/application-util/src/huawei.rs
@@ -1,14 +1,14 @@
 use reqwest::{Client, Method, Request, RequestBuilder, Url};
 
 use crate::http;
-use crate::http::map_request_err;
 use application_kernel::result::Error;
 use application_kernel::result::Result;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, de};
+use serde_json::Value;
 use tracing::warn;
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct TokenResponse {
     pub token_type: String,
     pub access_token: String,
@@ -18,10 +18,51 @@ pub struct TokenResponse {
     pub id_token: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct RawTokenResponse {
+    pub token_type: String,
+    pub access_token: String,
+    pub scope: String,
+    pub expires_in: i64,
+    pub refresh_token: String,
+    pub id_token: String,
+}
+
+impl<'de> Deserialize<'de> for TokenResponse {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        if let Some(error) = value.get("error").and_then(|e| e.as_str())
+            && !error.is_empty()
+        {
+            let err: TokenResponseError =
+                serde_json::from_value(value).map_err(de::Error::custom)?;
+            return Err(de::Error::custom(format!(
+                "第三方错误: 华为 API 响应业务结果出错，请联系管理员: {}",
+                err.error_description
+            )));
+        }
+
+        serde_json::from_value::<RawTokenResponse>(value)
+            .map(|raw| TokenResponse {
+                token_type: raw.token_type,
+                access_token: raw.access_token,
+                scope: raw.scope,
+                expires_in: raw.expires_in,
+                refresh_token: raw.refresh_token,
+                id_token: raw.id_token,
+            })
+            .map_err(de::Error::custom)
+    }
+}
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct TokenResponseError {
-    pub error: i64,
+    pub error: String,
     pub error_description: String,
 }
 
@@ -45,26 +86,62 @@ pub async fn token(code: &str, app_id: &str, client_secret: &str) -> Result<Toke
     )
     .form(&form);
 
-    http::request::<TokenResponse, TokenResponseError>(builder.build().map_err(|e| {
+    http::request::<TokenResponse>(builder.build().map_err(|e| {
         warn!("请求构建失败: {:?}", e);
         Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
     })?)
     .await
-    .map_err(|e| map_request_err(e, "华为"))?
-    .inner
-    .into_success()
-    .ok_or(Error::ThirdHttpResponseResult(None))
+    .map(|response| response.inner)
 }
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct TokenInfoResponse {
+    pub client_id: String,
+    pub expire_in: i64,
+    pub union_id: String,
+    pub project_id: String,
+    pub r#type: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawTokenInfoResponse {
     pub client_id: String,
     pub expire_in: i64,
     pub union_id: String,
     pub project_id: String,
     #[serde(rename = "type")]
     pub r#type: i64,
+}
+
+impl<'de> Deserialize<'de> for TokenInfoResponse {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        if let Some(error) = value.get("error").and_then(|e| e.as_str())
+            && !error.is_empty()
+        {
+            let err: TokenInfoResponseError =
+                serde_json::from_value(value).map_err(de::Error::custom)?;
+            return Err(de::Error::custom(format!(
+                "第三方错误: 华为 API 响应业务结果出错，请联系管理员: {}",
+                err.error
+            )));
+        }
+
+        serde_json::from_value::<RawTokenInfoResponse>(value)
+            .map(|raw| TokenInfoResponse {
+                client_id: raw.client_id,
+                expire_in: raw.expire_in,
+                union_id: raw.union_id,
+                project_id: raw.project_id,
+                r#type: raw.r#type,
+            })
+            .map_err(de::Error::custom)
+    }
 }
 
 #[allow(dead_code)]
@@ -88,13 +165,81 @@ pub async fn token_info(access_token: &str) -> Result<TokenInfoResponse> {
     )
         .form(&form);
 
-    http::request::<TokenInfoResponse, TokenInfoResponseError>(builder.build().map_err(|e| {
+    http::request::<TokenInfoResponse>(builder.build().map_err(|e| {
         warn!("请求构建失败: {:?}", e);
         Error::ThirdHttpRequest(Some("请求构建失败".to_string()))
     })?)
     .await
-    .map_err(|e| map_request_err(e, "华为"))?
-    .inner
-    .into_success()
-    .ok_or(Error::ThirdHttpResponseResult(None))
+    .map(|response| response.inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TokenInfoResponse, TokenResponse};
+
+    #[test]
+    fn deserialize_token_response_success() {
+        let value = serde_json::json!({
+            "token_type": "Bearer",
+            "access_token": "access",
+            "scope": "scope",
+            "expires_in": 123,
+            "refresh_token": "refresh",
+            "id_token": "id"
+        });
+
+        let resp: TokenResponse = serde_json::from_value(value).expect("should deserialize");
+        assert_eq!(resp.token_type, "Bearer");
+        assert_eq!(resp.access_token, "access");
+        assert_eq!(resp.scope, "scope");
+        assert_eq!(resp.expires_in, 123);
+        assert_eq!(resp.refresh_token, "refresh");
+        assert_eq!(resp.id_token, "id");
+    }
+
+    #[test]
+    fn deserialize_token_response_error() {
+        let value = serde_json::json!({
+            "error": "invalid_grant",
+            "error_description": "bad code"
+        });
+
+        let err = serde_json::from_value::<TokenResponse>(value).expect_err("should fail");
+        assert!(
+            err.to_string()
+                .contains("第三方错误: 华为 API 响应业务结果出错，请联系管理员: bad code")
+        );
+    }
+
+    #[test]
+    fn deserialize_token_info_response_success() {
+        let value = serde_json::json!({
+            "client_id": "client",
+            "expire_in": 3600,
+            "union_id": "uid",
+            "project_id": "pid",
+            "type": 1
+        });
+
+        let resp: TokenInfoResponse = serde_json::from_value(value).expect("should deserialize");
+        assert_eq!(resp.client_id, "client");
+        assert_eq!(resp.expire_in, 3600);
+        assert_eq!(resp.union_id, "uid");
+        assert_eq!(resp.project_id, "pid");
+        assert_eq!(resp.r#type, 1);
+    }
+
+    #[test]
+    fn deserialize_token_info_response_error() {
+        let value = serde_json::json!({
+            "error": "invalid_token",
+            "error_description": "token expired"
+        });
+
+        let err = serde_json::from_value::<TokenInfoResponse>(value).expect_err("should fail");
+        assert!(
+            err.to_string()
+                .contains("第三方错误: 华为 API 响应业务结果出错，请联系管理员: invalid_token")
+        );
+    }
 }

--- a/application-rs/application-util/src/wechat.rs
+++ b/application-rs/application-util/src/wechat.rs
@@ -2,17 +2,60 @@ use reqwest::{Method, Request, Url};
 use tracing::warn;
 
 use crate::http;
-use crate::http::map_request_err;
 use application_kernel::result::Error;
 use application_kernel::result::Result;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, de};
+use serde_json::Value;
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct LoginResponse {
     pub session_key: String,
     pub unionid: String,
     pub openid: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RawLoginResponse {
+    pub session_key: String,
+    pub unionid: String,
+    pub openid: String,
+}
+
+impl<'de> Deserialize<'de> for LoginResponse {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        if let Some(errcode) = value.get("errcode").and_then(|c| c.as_i64()) {
+            if errcode == 0 {
+                return serde_json::from_value::<RawLoginResponse>(value)
+                    .map(|raw| LoginResponse {
+                        session_key: raw.session_key,
+                        unionid: raw.unionid,
+                        openid: raw.openid,
+                    })
+                    .map_err(de::Error::custom);
+            } else {
+                let err: LoginResponseError =
+                    serde_json::from_value(value).map_err(de::Error::custom)?;
+                return Err(de::Error::custom(format!(
+                    "第三方错误: 微信 API 响应业务结果出错，请联系管理员: {}",
+                    err.errmsg
+                )));
+            }
+        }
+
+        serde_json::from_value::<RawLoginResponse>(value)
+            .map(|raw| LoginResponse {
+                session_key: raw.session_key,
+                unionid: raw.unionid,
+                openid: raw.openid,
+            })
+            .map_err(de::Error::custom)
+    }
 }
 
 #[allow(dead_code)]
@@ -36,10 +79,43 @@ pub async fn login(code: &str, app_id: &str, app_secret: &str) -> Result<LoginRe
             Error::ThirdHttpRequest(Some("URL 格式无效".to_string()))
         })?;
 
-    http::request::<LoginResponse, LoginResponseError>(Request::new(Method::GET, url))
+    http::request::<LoginResponse>(Request::new(Method::GET, url))
         .await
-        .map_err(|e| map_request_err(e, "微信"))?
-        .inner
-        .into_success()
-        .ok_or(Error::ThirdHttpResponseResult(None))
+        .map(|response| response.inner)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LoginResponse;
+
+    #[test]
+    fn deserialize_success_response() {
+        let value = serde_json::json!({
+            "errcode": 0,
+            "session_key": "sk",
+            "unionid": "uid",
+            "openid": "oid"
+        });
+
+        let resp: LoginResponse = serde_json::from_value(value).expect("should deserialize");
+
+        assert_eq!(resp.session_key, "sk");
+        assert_eq!(resp.unionid, "uid");
+        assert_eq!(resp.openid, "oid");
+    }
+
+    #[test]
+    fn deserialize_error_response() {
+        let value = serde_json::json!({
+            "errcode": 40029,
+            "errmsg": "invalid code"
+        });
+
+        let err = serde_json::from_value::<LoginResponse>(value).expect_err("should fail");
+
+        assert!(
+            err.to_string()
+                .contains("第三方错误: 微信 API 响应业务结果出错，请联系管理员: invalid code")
+        );
+    }
 }

--- a/application-rs/application-util/src/wechat.rs
+++ b/application-rs/application-util/src/wechat.rs
@@ -1,7 +1,9 @@
 use reqwest::{Method, Request, Url};
+use tracing::warn;
 
 use crate::http;
 use crate::http::map_request_err;
+use application_kernel::result::Error;
 use application_kernel::result::Result;
 use serde::Deserialize;
 
@@ -28,12 +30,16 @@ pub async fn login(code: &str, app_id: &str, app_secret: &str) -> Result<LoginRe
         ("grant_type", "authorization_code"),
     ];
 
-    let response = http::request::<LoginResponse, LoginResponseError>(Request::new(
-        Method::GET,
-        Url::parse_with_params("https://api.weixin.qq.com/sns/jscode2session", query).unwrap(),
-    ))
-    .await
-    .map_err(|e| map_request_err(e, "微信"))?;
+    let url = Url::parse_with_params("https://api.weixin.qq.com/sns/jscode2session", query)
+        .map_err(|e| {
+            warn!("URL 解析失败: {:?}", e);
+            Error::ThirdHttpRequest(Some("URL 格式无效".to_string()))
+        })?;
 
-    Ok(response.inner.into_success().unwrap())
+    let response =
+        http::request_success::<LoginResponse, LoginResponseError>(Request::new(Method::GET, url))
+            .await
+            .map_err(|e| map_request_err(e, "微信"))?;
+
+    Ok(response)
 }

--- a/application-rs/application-util/src/wechat.rs
+++ b/application-rs/application-util/src/wechat.rs
@@ -36,10 +36,10 @@ pub async fn login(code: &str, app_id: &str, app_secret: &str) -> Result<LoginRe
             Error::ThirdHttpRequest(Some("URL 格式无效".to_string()))
         })?;
 
-    let response =
-        http::request_success::<LoginResponse, LoginResponseError>(Request::new(Method::GET, url))
-            .await
-            .map_err(|e| map_request_err(e, "微信"))?;
-
-    Ok(response)
+    http::request::<LoginResponse, LoginResponseError>(Request::new(Method::GET, url))
+        .await
+        .map_err(|e| map_request_err(e, "微信"))?
+        .inner
+        .into_success()
+        .ok_or(Error::ThirdHttpResponseResult(None))
 }

--- a/application-rs/application-util/src/wechat.rs
+++ b/application-rs/application-util/src/wechat.rs
@@ -1,5 +1,5 @@
 use reqwest::{Method, Request, Url};
-use tracing::warn;
+use tracing::error;
 
 use crate::http;
 use application_kernel::result::Error;
@@ -75,7 +75,7 @@ pub async fn login(code: &str, app_id: &str, app_secret: &str) -> Result<LoginRe
 
     let url = Url::parse_with_params("https://api.weixin.qq.com/sns/jscode2session", query)
         .map_err(|e| {
-            warn!("URL 解析失败: {:?}", e);
+            error!("URL 解析失败: {:?}", e);
             Error::ThirdHttpRequest(Some("URL 格式无效".to_string()))
         })?;
 


### PR DESCRIPTION
## Summary

- 移除 `#[serde(untagged)]`，改为自定义 `Deserialize` 实现
- 根据微信/华为 API 的错误字段精确判别成功/失败
- 提升反序列化性能和准确性

## Changes

### ResponseVariant 反序列化优化

- 移除 `#[serde(untagged)]` 和 `#[derive(Deserialize)]`
- 手动实现 `Deserialize` trait
- 添加三层判别逻辑：
  1. `errcode == 0` → Success（微信）
  2. `error` 存在且非空 → Error（华为）
  3. 兜底：先尝试 Success，失败则尝试 Error
- 移除未使用的 `parse` 方法

### 为什么需要这个改动

`#[serde(untagged)]` 的问题：
1. **性能问题** - 按声明顺序盲试，每次反序列化都要尝试两次
2. **误解析风险** - 如果 Success 和 Error 结构体有相似字段，可能错误匹配
3. **错误信息模糊** - 匹配失败时难以调试

## Verification

- ✅ `cargo check --all-features` - 编译通过
- ✅ `cargo clippy -- -D warnings` - 无警告
- ✅ `cargo test --all-features` - 4 个测试全部通过