### PR TITLE
refactor(database): 统一数据库查询使用 macros.rs 宏

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.sisyphus/

--- a/application-rs/application-database/src/account/refresh_token.rs
+++ b/application-rs/application-database/src/account/refresh_token.rs
@@ -1,13 +1,11 @@
-use crate::Pool;
 use crate::account::access_token;
 use crate::account::access_token::AccessToken;
+use crate::{Pool, insert, query_optional, update};
 use application_kernel::config::G_CONFIG;
 use application_kernel::result::{Error, Result};
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
-use std::time::Instant;
-use tracing::{error, info};
 use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
@@ -39,21 +37,9 @@ pub async fn update_or_insert(access_token_id: u64) -> Result<RefreshToken> {
 
 pub async fn fetch(refresh_token: &str) -> Result<RefreshToken> {
     let sql = "select * from account.refresh_token where refresh_token = ? limit 1";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let result: Option<RefreshToken> = sqlx::query_as(sql)
-        .bind(refresh_token)
-        .fetch_optional(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("查询 refresh_token 失败: {:?}", e);
-
-            Error::InternalDatabaseQuery(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, refresh_token);
+    let result: Option<RefreshToken> = query_optional!(pool, sql, refresh_token);
 
     if let Some(data) = result {
         return Ok(data);
@@ -64,21 +50,9 @@ pub async fn fetch(refresh_token: &str) -> Result<RefreshToken> {
 
 pub async fn fetch_by_access_token_id(access_token_id: u64) -> Result<RefreshToken> {
     let sql = "select * from account.refresh_token where access_token_id = ? limit 1";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let result: Option<RefreshToken> = sqlx::query_as(sql)
-        .bind(access_token_id)
-        .fetch_optional(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("查询 refresh_token 失败: {:?}", e);
-
-            Error::InternalDatabaseQuery(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, access_token_id);
+    let result: Option<RefreshToken> = query_optional!(pool, sql, access_token_id);
 
     if let Some(data) = result {
         return Ok(data);
@@ -91,26 +65,12 @@ pub async fn insert(access_token_id: u64) -> Result<RefreshToken> {
     let sql = "insert into account.refresh_token (access_token_id, refresh_token, expired_at) values (?, ?, ?)";
     let refresh_token = Uuid::now_v7().to_string();
     let expired_at = G_CONFIG.access_token.get_refresh_expired_at();
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let result = sqlx::query(sql)
-        .bind(access_token_id)
-        .bind(&refresh_token)
-        .bind(expired_at)
-        .execute(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("插入 refresh_token 失败: {:?}", e);
-
-            Error::InternalDatabaseInsert(None)
-        });
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, access_token_id);
+    let result = insert!(pool, sql, access_token_id, &refresh_token, expired_at);
 
     Ok(RefreshToken {
-        id: result?.last_insert_id(),
+        id: result.last_insert_id(),
         access_token_id,
         refresh_token,
         expired_at,
@@ -123,23 +83,15 @@ pub async fn update(mut refresh_token: RefreshToken) -> Result<RefreshToken> {
     let sql = "update account.refresh_token set refresh_token = ?, expired_at = ? where id = ?";
     let refresh_token_value = Uuid::now_v7().to_string();
     let expired_at = G_CONFIG.access_token.get_refresh_expired_at();
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let _ = sqlx::query(sql)
-        .bind(&refresh_token_value)
-        .bind(expired_at)
-        .bind(refresh_token.id)
-        .execute(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("更新 refresh_token 失败: {:?}", e);
-
-            Error::InternalDatabaseUpdate(None)
-        });
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, refresh_token.id);
+    let _ = update!(
+        pool,
+        sql,
+        &refresh_token_value,
+        expired_at,
+        refresh_token.id
+    );
 
     refresh_token.refresh_token = refresh_token_value;
     refresh_token.expired_at = expired_at;

--- a/application-rs/application-database/src/account/third_config.rs
+++ b/application-rs/application-database/src/account/third_config.rs
@@ -1,13 +1,11 @@
-use crate::Pool;
 use crate::account::Platform;
+use crate::{Pool, query_optional};
 
 use application_kernel::result::Error;
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use sqlx::types::Json;
-use std::time::Instant;
-use tracing::{error, info};
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct ThirdConfig {
@@ -42,22 +40,9 @@ pub async fn fetch(
     third_id: &str,
 ) -> application_kernel::result::Result<ThirdConfig> {
     let sql = "select * from account.third_config where platform = ? and third_id = ? limit 1";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let result: Option<ThirdConfig> = sqlx::query_as(sql)
-        .bind(platform)
-        .bind(third_id)
-        .fetch_optional(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("查询第三方平台配置信息失败: {:?}", e);
-
-            Error::InternalDatabaseQuery(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, third_id);
+    let result: Option<ThirdConfig> = query_optional!(pool, sql, platform, third_id);
 
     if let Some(config) = result {
         return Ok(config);

--- a/application-rs/application-database/src/account/third_user.rs
+++ b/application-rs/application-database/src/account/third_user.rs
@@ -1,13 +1,11 @@
-use crate::Pool;
 use crate::account::Platform;
 use crate::account::user::Config;
+use crate::{Pool, insert, query_optional};
 use application_kernel::result::Error;
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use sqlx::types::Json;
-use std::time::Instant;
-use tracing::{error, info};
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct ThirdUser {
@@ -25,22 +23,9 @@ pub async fn fetch(
     third_id: &str,
 ) -> application_kernel::result::Result<ThirdUser> {
     let sql = "select * from account.third_user where platform = ? and third_id = ? limit 1";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let result: Option<ThirdUser> = sqlx::query_as(sql)
-        .bind(platform)
-        .bind(third_id)
-        .fetch_optional(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("查询第三方平台用户失败: {:?}", e);
-
-            Error::InternalDatabaseQuery(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, third_id);
+    let result: Option<ThirdUser> = query_optional!(pool, sql, platform, third_id);
 
     if let Some(third_user) = result {
         return Ok(third_user);
@@ -55,23 +40,9 @@ pub async fn insert(
     user_id: u64,
 ) -> application_kernel::result::Result<u64> {
     let sql = "insert into account.third_user (platform, third_id, user_id) values (?, ?, ?)";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let result = sqlx::query(sql)
-        .bind(platform)
-        .bind(third_id)
-        .bind(user_id)
-        .execute(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("查询第三方平台用户失败: {:?}", e);
+    let result = insert!(pool, sql, platform, third_id, user_id);
 
-            Error::InternalDatabaseInsert(None)
-        });
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, third_id);
-
-    Ok(result?.last_insert_id())
+    Ok(result.last_insert_id())
 }

--- a/application-rs/application-database/src/account/user.rs
+++ b/application-rs/application-database/src/account/user.rs
@@ -1,11 +1,9 @@
-use crate::Pool;
+use crate::{Pool, insert, query_optional, update};
 use application_kernel::result::Error;
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use sqlx::types::Json;
-use std::time::Instant;
-use tracing::{error, info};
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct User {
@@ -25,21 +23,9 @@ pub struct Config {
 
 pub async fn fetch(user_id: u64) -> application_kernel::result::Result<User> {
     let sql = "select * from account.user where id = ? limit 1";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let result: Option<User> = sqlx::query_as(sql)
-        .bind(user_id)
-        .fetch_optional(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("查询用户失败: {:?}", e);
-
-            Error::InternalDatabaseQuery(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, user_id);
+    let result: Option<User> = query_optional!(pool, sql, user_id);
 
     if let Some(user) = result {
         return Ok(user);
@@ -53,133 +39,54 @@ pub async fn insert(
     config: Config,
 ) -> application_kernel::result::Result<u64> {
     let sql = "insert into account.user (phone, config) values (?, ?)";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let result = sqlx::query(sql)
-        .bind(phone)
-        .bind(Json(&config))
-        .execute(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("插入用户失败: {:?}", e);
-
-            Error::InternalDatabaseInsert(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, phone, ?config);
+    let result = insert!(pool, sql, phone, Json(&config));
 
     Ok(result.last_insert_id())
 }
 
 pub async fn update_avatar(id: u64, avatar: &str) -> application_kernel::result::Result<()> {
     let sql = "update account.user set config = json_set(config, '$.avatar', ?) where id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let _ = sqlx::query(sql)
-        .bind(avatar)
-        .bind(id)
-        .execute(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("更新用户失败: {:?}", e);
-
-            Error::InternalDatabaseUpdate(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let _ = update!(pool, sql, avatar, id);
 
     Ok(())
 }
 
 pub async fn update_nickname(id: u64, nickname: &str) -> application_kernel::result::Result<()> {
     let sql = "update account.user set config = json_set(config, '$.nickname', ?) where id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let _ = sqlx::query(sql)
-        .bind(nickname)
-        .bind(id)
-        .execute(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("更新昵称失败: {:?}", e);
-
-            Error::InternalDatabaseUpdate(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let _ = update!(pool, sql, nickname, id);
 
     Ok(())
 }
 
 pub async fn update_slogan(id: u64, slogan: &str) -> application_kernel::result::Result<()> {
     let sql = "update account.user set config = json_set(config, '$.slogan', ?) where id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let _ = sqlx::query(sql)
-        .bind(slogan)
-        .bind(id)
-        .fetch_one(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("更新 Slogan 失败: {:?}", e);
-
-            Error::InternalDatabaseUpdate(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let _ = update!(pool, sql, slogan, id);
 
     Ok(())
 }
 
 pub async fn update_phone(id: u64, phone: &str) -> application_kernel::result::Result<()> {
     let sql = "update account.user set phone = ? where id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let _ = sqlx::query(sql)
-        .bind(phone)
-        .bind(id)
-        .execute(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("更新手机号失败: {:?}", e);
-
-            Error::InternalDatabaseUpdate(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let _ = update!(pool, sql, phone, id);
 
     Ok(())
 }
 
 pub async fn flush(id: u64) -> application_kernel::result::Result<()> {
     let sql = "update account.user set phone = ?, config = ? where id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("account")?;
 
-    let _ = sqlx::query(sql)
-        .bind(None::<&str>)
-        .bind(Json(&Config::default()))
-        .bind(id)
-        .execute(Pool::mysql("account")?)
-        .await
-        .map_err(|e| {
-            error!("清除用户个人设置失败: {:?}", e);
-
-            Error::InternalDatabaseUpdate(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let _ = update!(pool, sql, None::<&str>, Json(&Config::default()), id);
 
     Ok(())
 }

--- a/application-rs/application-database/src/macros.rs
+++ b/application-rs/application-database/src/macros.rs
@@ -9,7 +9,36 @@ macro_rules! query_optional {
             .await;
 
         let elapsed = started_at.elapsed().as_secs_f32();
-        tracing::info!(elapsed, sql);
+
+        let mut binds: Vec<String> = Vec::new();
+        $(binds.push(format!("{:?}", $bind));)*
+
+        tracing::info!(elapsed, sql, ?binds);
+
+        result.map_err(|e| {
+            tracing::error!("数据库查询失败: {:?}", e);
+
+            application_kernel::result::Error::InternalDatabaseQuery(None)
+        })?
+    }};
+}
+
+#[macro_export]
+macro_rules! query_all {
+    ($pool:expr, $sql:expr $(, $bind:expr)*) => {{
+        let sql = $sql;
+        let started_at = std::time::Instant::now();
+        let result = sqlx::query_as(sql)
+            $(.bind($bind))*
+            .fetch_all($pool)
+            .await;
+
+        let elapsed = started_at.elapsed().as_secs_f32();
+
+        let mut binds: Vec<String> = Vec::new();
+        $(binds.push(format!("{:?}", $bind));)*
+
+        tracing::info!(elapsed, sql, ?binds);
 
         result.map_err(|e| {
             tracing::error!("数据库查询失败: {:?}", e);
@@ -30,7 +59,11 @@ macro_rules! execute {
             .await;
 
         let elapsed = started_at.elapsed().as_secs_f32();
-        tracing::info!(elapsed, sql);
+
+        let mut binds: Vec<String> = Vec::new();
+        $(binds.push(format!("{:?}", $bind));)*
+
+        tracing::info!(elapsed, sql, ?binds);
 
         result.map_err(|e| {
             tracing::error!("数据库写入失败: {:?}", e);
@@ -69,6 +102,22 @@ macro_rules! update {
             );
         }
         $crate::execute!($pool, $sql, application_kernel::result::Error::InternalDatabaseUpdate(None) $(, $bind)*)
+    }};
+}
+
+#[macro_export]
+macro_rules! delete {
+    ($pool:expr, $sql:expr $(, $bind:expr)*) => {{
+        #[cfg(debug_assertions)]
+        {
+            let sql_upper = $sql.to_uppercase();
+            assert!(
+                sql_upper.starts_with("DELETE"),
+                "delete! 宏要求 SQL 以 DELETE 开头，实际为: {}",
+                $sql
+            );
+        }
+        $crate::execute!($pool, $sql, application_kernel::result::Error::InternalDatabaseDelete(None) $(, $bind)*)
     }};
 }
 

--- a/application-rs/application-database/src/tool/short_url.rs
+++ b/application-rs/application-database/src/tool/short_url.rs
@@ -1,10 +1,8 @@
-use crate::Pool;
+use crate::{Pool, insert, query_optional, update};
 use application_kernel::result::Error;
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
-use std::time::Instant;
-use tracing::{error, info};
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct ShortUrl {
@@ -24,21 +22,9 @@ pub struct CreateShortUrl {
 
 pub async fn fetch(short: &str) -> application_kernel::result::Result<ShortUrl> {
     let sql = "select * from tool.short_url where short = ? limit 1";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    let result: Option<ShortUrl> = sqlx::query_as(sql)
-        .bind(short)
-        .fetch_optional(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("查询短连接失败: {:?}", e);
-
-            Error::InternalDatabaseQuery(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, short);
+    let result: Option<ShortUrl> = query_optional!(pool, sql, short);
 
     if let Some(short_url) = result {
         return Ok(short_url);
@@ -49,25 +35,12 @@ pub async fn fetch(short: &str) -> application_kernel::result::Result<ShortUrl> 
 
 pub async fn insert(url: CreateShortUrl) -> application_kernel::result::Result<ShortUrl> {
     let sql = "insert into tool.short_url (short, url) values (?, ?)";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    let result = sqlx::query(sql)
-        .bind(&url.short)
-        .bind(&url.url)
-        .execute(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("插入短连接失败: {:?}", e);
-
-            Error::InternalDatabaseInsert(None)
-        });
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, ?url);
+    let result = insert!(pool, sql, &url.short, &url.url);
 
     Ok(ShortUrl {
-        id: result?.last_insert_id(),
+        id: result.last_insert_id(),
         short: url.short,
         url: url.url,
         visit: 0,
@@ -78,21 +51,9 @@ pub async fn insert(url: CreateShortUrl) -> application_kernel::result::Result<S
 
 pub async fn update_count(id: u64) -> application_kernel::result::Result<()> {
     let sql = "update tool.short_url set visit = visit + 1 where id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    sqlx::query(sql)
-        .bind(id)
-        .execute(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("更新短连接访问次数失败: {:?}", e);
-
-            Error::InternalDatabaseUpdate(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let _ = update!(pool, sql, id);
 
     Ok(())
 }

--- a/application-rs/application-database/src/tool/totp.rs
+++ b/application-rs/application-database/src/tool/totp.rs
@@ -1,12 +1,11 @@
-use crate::Pool;
+use crate::{Pool, delete, insert, query_all, query_optional, update};
 use application_kernel::result::{Error, Result};
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use sqlx::types::Json;
-use std::time::Instant;
 use totp_rs::{Algorithm, Secret, TOTP};
-use tracing::{error, info};
+use tracing::error;
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Totp {
@@ -71,42 +70,16 @@ pub struct CreatedTotp {
 
 pub async fn all(user_id: u64) -> Result<Vec<Totp>> {
     let sql = "select * from tool.totp where user_id = ? order by id asc";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    let result = sqlx::query_as(sql)
-        .bind(user_id)
-        .fetch_all(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("查询用户所有的 Totp 失败: {:?}", e);
-
-            Error::InternalDatabaseQuery(None)
-        });
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, user_id);
-
-    result
+    Ok(query_all!(pool, sql, user_id))
 }
 
 pub async fn fetch(id: u64) -> Result<Totp> {
     let sql = "select * from tool.totp where id = ? limit 1";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    let result: Option<Totp> = sqlx::query_as(sql)
-        .bind(id)
-        .fetch_optional(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("查询 Totp 详情失败: {:?}", e);
-
-            Error::InternalDatabaseQuery(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let result: Option<Totp> = query_optional!(pool, sql, id);
 
     if let Some(user) = result {
         return Ok(user);
@@ -117,27 +90,19 @@ pub async fn fetch(id: u64) -> Result<Totp> {
 
 pub async fn insert(totp: CreatedTotp) -> Result<Totp> {
     let sql = "insert into tool.totp (user_id, username, issuer, config) values (?, ?, ?, ?)";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    let result = sqlx::query(sql)
-        .bind(totp.user_id)
-        .bind(&totp.username)
-        .bind(&totp.issuer)
-        .bind(Json(&(totp.config)))
-        .execute(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("插入 Totp 失败: {:?}", e);
-
-            Error::InternalDatabaseInsert(None)
-        });
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, ?totp);
+    let result = insert!(
+        pool,
+        sql,
+        totp.user_id,
+        &totp.username,
+        &totp.issuer,
+        Json(&(totp.config))
+    );
 
     Ok(Totp {
-        id: result?.last_insert_id(),
+        id: result.last_insert_id(),
         user_id: totp.user_id,
         username: totp.username,
         issuer: totp.issuer,
@@ -149,86 +114,36 @@ pub async fn insert(totp: CreatedTotp) -> Result<Totp> {
 
 pub async fn update_issuer(id: u64, issuer: &str) -> Result<()> {
     let sql = "update tool.totp set issuer = ? where id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    let _ = sqlx::query(sql)
-        .bind(issuer)
-        .bind(id)
-        .execute(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("更新 TOTP 的 issuer 失败: {:?}", e);
-
-            Error::InternalDatabaseUpdate(None)
-        });
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let _ = update!(pool, sql, issuer, id);
 
     Ok(())
 }
 
 pub async fn update_username(id: u64, username: &str) -> Result<()> {
     let sql = "update tool.totp set username = ? where id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    let _ = sqlx::query(sql)
-        .bind(username)
-        .bind(id)
-        .execute(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("更新 TOTP 的 username 失败: {:?}", e);
-
-            Error::InternalDatabaseUpdate(None)
-        });
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let _ = update!(pool, sql, username, id);
 
     Ok(())
 }
 
 pub async fn delete(id: u64) -> Result<()> {
     let sql = "delete from tool.totp where id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    sqlx::query(sql)
-        .bind(id)
-        .execute(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("删除 Totp 失败: {:?}", e);
-
-            Error::InternalDatabaseDelete(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, id);
+    let _ = delete!(pool, sql, id);
 
     Ok(())
 }
 
 pub async fn delete_by_user(user_id: u64) -> Result<()> {
     let sql = "delete from tool.totp where user_id = ?";
-    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
 
-    sqlx::query(sql)
-        .bind(user_id)
-        .execute(Pool::mysql("tool")?)
-        .await
-        .map_err(|e| {
-            error!("根据 user_id 删除 Totp 失败: {:?}", e);
-
-            Error::InternalDatabaseDelete(None)
-        })?;
-
-    let elapsed = started_at.elapsed().as_secs_f32();
-
-    info!(elapsed, sql, user_id);
+    let _ = delete!(pool, sql, user_id);
 
     Ok(())
 }


### PR DESCRIPTION
## 变更内容

统一 application-database 中所有数据库查询为 macros.rs 中的宏调用，消除重复样板代码。

### 新增宏
- `query_all!`：支持 `fetch_all` 查询
- `delete!`：支持 DELETE 语句（含 SQL 前缀校验）

### 宏增强
- `query_optional!`、`query_all!`、`execute!` 增加 bind 参数日志打印

### 文件变更
- `tool/short_url.rs`
- `tool/totp.rs`
- `account/user.rs`
- `account/third_user.rs`
- `account/refresh_token.rs`
- `account/third_config.rs`

### 额外修复
- `user.rs` 中 `update_slogan` 原代码错误使用 `.fetch_one()` 执行 UPDATE，已修正为 `update!`

### 未改动
- `totp.rs` 中 `sort()` 函数的事务循环保持原样（宏不支持事务连接参数）