### PR TITLE
feat(totp): 添加 TOTP 排序功能

### DIFF
--- a/application-rs/application-api/src/request/totp.rs
+++ b/application-rs/application-api/src/request/totp.rs
@@ -171,3 +171,48 @@ impl Validator for DeleteRequest {
             .map_err(|_| Error::ParamsTotpIdEmpty(None))
     }
 }
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SortRequest {
+    pub items: Option<Vec<SortRequestItem>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SortRequestItem {
+    pub id: Option<String>,
+    pub sort: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SortItemParams {
+    pub id: u64,
+    pub sort: u32,
+}
+
+impl Validator for SortRequest {
+    type Data = Vec<SortItemParams>;
+
+    fn validate(&self) -> application_kernel::result::Result<Self::Data> {
+        let items = self.items.as_ref().ok_or(Error::ParamsTotpIdEmpty(None))?;
+
+        if items.is_empty() {
+            return Err(Error::ParamsTotpIdEmpty(None));
+        }
+
+        items
+            .iter()
+            .map(|item| {
+                let id = item
+                    .id
+                    .as_deref()
+                    .ok_or(Error::ParamsTotpIdEmpty(None))?
+                    .parse::<u64>()
+                    .map_err(|_| Error::ParamsTotpIdEmpty(None))?;
+
+                let sort = item.sort.ok_or(Error::ParamsTotpIdEmpty(None))?;
+
+                Ok(SortItemParams { id, sort })
+            })
+            .collect()
+    }
+}

--- a/application-rs/application-api/src/routes.rs
+++ b/application-rs/application-api/src/routes.rs
@@ -72,6 +72,7 @@ fn api_v1_totp() -> Router {
         .push(Router::with_path("/all").post(v1::totp::all))
         .push(Router::with_path("/detail").post(v1::totp::detail))
         .push(Router::with_path("/create").post(v1::totp::create))
+        .push(Router::with_path("/sort").post(v1::totp::sort))
         .push(
             Router::with_path("/edit")
                 .push(Router::with_path("/username").post(v1::totp::edit_username))

--- a/application-rs/application-api/src/service/totp.rs
+++ b/application-rs/application-api/src/service/totp.rs
@@ -1,7 +1,10 @@
-use crate::request::totp::{DetailResponse, EditIssuerRequestParams, EditUsernameRequestParams};
+use crate::request::totp::{
+    DetailResponse, EditIssuerRequestParams, EditUsernameRequestParams, SortItemParams,
+};
 use application_database::account::access_token;
 use application_database::tool::totp;
 use application_kernel::result::{Error, Result};
+use std::collections::BTreeSet;
 use totp_rs::{Secret, TOTP};
 use tracing::error;
 
@@ -9,6 +12,29 @@ pub async fn all(access_token: &access_token::AccessToken) -> Result<Vec<DetailR
     let totp = totp::all(access_token.user_id).await?;
 
     totp.into_iter().map(|t| t.try_into()).collect()
+}
+
+pub async fn sort(
+    access_token: &access_token::AccessToken,
+    items: Vec<SortItemParams>,
+) -> Result<()> {
+    let owned = totp::all(access_token.user_id).await?;
+    let owned_ids: BTreeSet<u64> = owned.iter().map(|t| t.id).collect();
+    let item_ids: BTreeSet<u64> = items.iter().map(|i| i.id).collect();
+
+    if owned_ids.len() != items.len() || item_ids.len() != items.len() || owned_ids != item_ids {
+        return Err(Error::AuthorizationPermissionUngranted(None));
+    }
+
+    let db_items = items
+        .iter()
+        .map(|item| totp::SortItem {
+            id: item.id,
+            sort: item.sort,
+        })
+        .collect::<Vec<_>>();
+
+    totp::sort(access_token.user_id, &db_items).await
 }
 
 pub async fn detail(access_token: &access_token::AccessToken, id: u64) -> Result<DetailResponse> {
@@ -31,6 +57,7 @@ pub async fn create(
 
     totp::insert(totp::CreatedTotp {
         user_id: access_token.user_id,
+        sort: None,
         username: totp.account_name,
         issuer: totp.issuer,
         config: totp::TotpConfig {

--- a/application-rs/application-api/src/v1/totp.rs
+++ b/application-rs/application-api/src/v1/totp.rs
@@ -3,13 +3,27 @@ use salvo::{Depot, Request, handler};
 use crate::request::Validator;
 use crate::request::totp::{
     CreateRequest, DeleteRequest, DetailRequest, DetailResponse, EditIssuerRequest,
-    EditUsernameRequest,
+    EditUsernameRequest, SortRequest,
 };
 use crate::response::Resp;
 use crate::response::Response;
 use crate::service;
 use application_database::account::access_token::AccessToken;
 use application_kernel::result::Error;
+
+#[handler]
+pub async fn sort(request: &mut Request, depot: &mut Depot) -> Resp<()> {
+    let access_token = depot
+        .obtain::<AccessToken>()
+        .map_err(|_| Error::AuthorizationAccessTokenInvalid(None))?;
+
+    let params = request.parse_json::<SortRequest>().await?;
+    let items = params.validate()?;
+
+    service::totp::sort(access_token, items).await?;
+
+    Ok(Response::success(()))
+}
 
 #[handler]
 pub async fn all(depot: &mut Depot) -> Resp<Vec<DetailResponse>> {

--- a/application-rs/application-database/src/tool/totp.rs
+++ b/application-rs/application-database/src/tool/totp.rs
@@ -4,13 +4,22 @@ use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use sqlx::types::Json;
+use std::time::Instant;
 use totp_rs::{Algorithm, Secret, TOTP};
 use tracing::error;
+use tracing::info;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SortItem {
+    pub id: u64,
+    pub sort: u32,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct Totp {
     pub id: u64,
     pub user_id: u64,
+    pub sort: u32,
     pub username: String,
     pub issuer: Option<String>,
     pub config: Json<TotpConfig>,
@@ -63,13 +72,14 @@ pub struct TotpConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreatedTotp {
     pub user_id: u64,
+    pub sort: Option<u32>,
     pub username: String,
     pub issuer: Option<String>,
     pub config: TotpConfig,
 }
 
 pub async fn all(user_id: u64) -> Result<Vec<Totp>> {
-    let sql = "select * from tool.totp where user_id = ? order by id asc";
+    let sql = "select * from tool.totp where user_id = ? order by sort desc, id asc";
     let pool = Pool::mysql("tool")?;
 
     Ok(query_all!(pool, sql, user_id))
@@ -104,6 +114,7 @@ pub async fn insert(totp: CreatedTotp) -> Result<Totp> {
     Ok(Totp {
         id: result.last_insert_id(),
         user_id: totp.user_id,
+        sort: 0,
         username: totp.username,
         issuer: totp.issuer,
         config: Json(totp.config),
@@ -144,6 +155,51 @@ pub async fn delete_by_user(user_id: u64) -> Result<()> {
     let pool = Pool::mysql("tool")?;
 
     let _ = delete!(pool, sql, user_id);
+
+    Ok(())
+}
+
+pub async fn sort(user_id: u64, items: &[SortItem]) -> Result<()> {
+    if items.is_empty() {
+        return Ok(());
+    }
+
+    let started_at = Instant::now();
+    let pool = Pool::mysql("tool")?;
+
+    let mut sql = String::from("UPDATE tool.totp SET sort = CASE id ");
+    for _ in items {
+        sql.push_str("WHEN ? THEN ? ");
+    }
+    sql.push_str("ELSE sort END WHERE id IN (");
+    for i in 0..items.len() {
+        if i > 0 {
+            sql.push(',');
+        }
+        sql.push('?');
+    }
+    sql.push_str(") AND user_id = ?");
+
+    let mut query = sqlx::query(&sql);
+    for item in items {
+        query = query.bind(item.id).bind(item.sort);
+    }
+    for item in items {
+        query = query.bind(item.id);
+    }
+    query = query.bind(user_id);
+
+    let result = query.execute(pool).await.map_err(|e| {
+        error!("批量更新 TOTP 排序失败: {:?}", e);
+        Error::InternalDatabaseUpdate(None)
+    })?;
+
+    if result.rows_affected() != items.len() as u64 {
+        return Err(Error::AuthorizationPermissionUngranted(None));
+    }
+
+    let elapsed = started_at.elapsed().as_secs_f32();
+    info!(elapsed, sql, user_id, item_count = items.len());
 
     Ok(())
 }

--- a/application-rs/database/07-add-sort-to-totp.sql
+++ b/application-rs/database/07-add-sort-to-totp.sql
@@ -1,0 +1,10 @@
+alter table tool.totp
+    add column sort bigint unsigned not null default 0;
+
+create index idx_tool_totp_user_sort
+    on tool.totp (user_id, sort);
+
+-- rollback
+drop index idx_tool_totp_user_sort on tool.totp;
+alter table tool.totp
+    drop column sort;


### PR DESCRIPTION
## Summary

- 数据库层：为 `tool.totp` 表添加 `sort` 字段，支持用户自定义排序
- API 层：新增 `POST /v1/totp/sort` 接口，接收 `{items: [{id, sort}]}` 格式参数
- 排序校验：严格校验传入的 ID 列表必须等于当前用户拥有的全部 TOTP ID，防止部分更新或越权
- 数据库更新：使用单条 `CASE WHEN ... END` SQL 批量更新，无需显式事务

## 数据库迁移

```sql
ALTER TABLE tool.totp ADD COLUMN sort INT UNSIGNED NOT NULL DEFAULT 0 AFTER user_id;
CREATE INDEX idx_totp_user_sort ON tool.totp(user_id, sort);
```

## 变更文件

| 文件 | 说明 |
|---|---|
| `application-database/src/tool/totp.rs` | 新增 `SortItem` / `sort()` 函数，单条 SQL 批量更新 |
| `application-api/src/v1/totp.rs` | 新增 `sort` handler |
| `application-api/src/service/totp.rs` | 排序权限校验逻辑 |
| `application-api/src/request/totp.rs` | `SortRequest` / `SortItemParams` DTO |
| `application-api/src/routes.rs` | 注册 `sort` 路由 |
| `database/07-add-sort-to-totp.sql` | 数据库迁移脚本 |