### PR TITLE
feat(wechat): TOTP 列表拖拽排序

### DIFF
--- a/wechat/biome.json
+++ b/wechat/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.2.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/wechat/miniprogram/api/totp.ts
+++ b/wechat/miniprogram/api/totp.ts
@@ -13,6 +13,13 @@ import type {
   Item,
 } from "types/totp";
 
+interface SortRequest {
+  items: Array<{
+    id: string;
+    sort: number;
+  }>;
+}
+
 const all = async () => {
   try {
     return await http.post<Item[]>(PATH.ALL);
@@ -79,4 +86,22 @@ const deleteTotp = async (id: string) => {
   }
 };
 
-export default { all, detail, create, editIssuer, editUsername, deleteTotp };
+const sort = async (items: SortRequest["items"]) => {
+  try {
+    return await http.post<null>("/api/v1/totp/sort", { items } as SortRequest);
+  } catch (e: unknown) {
+    logger.error("排序 TOTP 失败", e);
+
+    throw new HttpError(CODE.HTTP_API_TOTP_ALL, error.getErrorMessage(e));
+  }
+};
+
+export default {
+  all,
+  detail,
+  create,
+  editIssuer,
+  editUsername,
+  deleteTotp,
+  sort,
+};

--- a/wechat/miniprogram/app.scss
+++ b/wechat/miniprogram/app.scss
@@ -1,6 +1,6 @@
 page {
   height: 100%;
-  --td-brand-color: #0894FA;
+  --td-brand-color: #5bb43b;
 }
 
 .page {

--- a/wechat/miniprogram/custom-tab-bar/index.wxss
+++ b/wechat/miniprogram/custom-tab-bar/index.wxss
@@ -1,3 +1,3 @@
 .custom-tab-bar {
-  --td-tab-bar-active-color: #0894FA;
+  --td-tab-bar-active-color: #5bb43b;
 }

--- a/wechat/miniprogram/pages/totp/index.json
+++ b/wechat/miniprogram/pages/totp/index.json
@@ -5,6 +5,8 @@
     "t-empty": "tdesign-miniprogram/empty/empty",
     "t-fab": "tdesign-miniprogram/fab/fab",
     "t-dialog": "tdesign-miniprogram/dialog/dialog",
+    "t-button": "tdesign-miniprogram/button/button",
+    "t-icon": "tdesign-miniprogram/icon/icon",
     "app-totp-item": "/components/totp/item"
   },
   "navigationBarTitleText": "TOTP身份验证器"

--- a/wechat/miniprogram/pages/totp/index.scss
+++ b/wechat/miniprogram/pages/totp/index.scss
@@ -1,3 +1,57 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 16px;
+  background-color: #fff;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.header-title {
+  font-size: 13px;
+  font-weight: 400;
+  color: #999;
+}
+
 .items {
   padding-bottom: 100px;
+}
+
+.items-sort {
+  padding-bottom: 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.sort-item {
+  position: relative;
+  width: 100%;
+  height: 100px;
+}
+
+.sort-mask {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.sort-tip {
+  padding: 8px 16px;
+  background-color: #f9f9f9;
+  text-align: center;
+}
+
+.sort-tip-text {
+  font-size: 12px;
+  color: #999;
 }

--- a/wechat/miniprogram/pages/totp/index.ts
+++ b/wechat/miniprogram/pages/totp/index.ts
@@ -17,6 +17,11 @@ Page({
     dialogVisible: false,
     currentItemId: "0",
     items: [] as Item[],
+    isSortMode: false,
+    dragItems: [] as (Item & { y: number })[],
+    draggingIndex: -1,
+    draggingId: "",
+    dragCurrentY: 0,
   },
   onShow() {
     this.all();
@@ -117,5 +122,84 @@ Page({
   },
   dialogCancel() {
     this.setData({ dialogVisible: false, currentItemId: "0" });
+  },
+  enterSortMode() {
+    this.setData({
+      isSortMode: true,
+      dragItems: this.data.items.map((item, index) => ({
+        ...item,
+        y: index * 100,
+      })),
+    });
+  },
+  exitSortMode() {
+    this.setData({ isSortMode: false });
+  },
+  onDragStart(e: WechatMiniprogram.TouchEvent) {
+    const index = Number(e.currentTarget.dataset.index);
+    this.setData({ draggingIndex: index });
+  },
+  onDragChange(e: WechatMiniprogram.MovableViewChange) {
+    if (e.detail.source === "touch") {
+      this.data.dragCurrentY = e.detail.y;
+    }
+  },
+  onDragEnd(e: WechatMiniprogram.TouchEvent) {
+    const index = Number(e.currentTarget.dataset.index);
+    if (this.data.draggingIndex !== index) return;
+
+    const y = this.data.dragCurrentY;
+    let newIndex = Math.round(y / 100);
+    newIndex = Math.max(0, Math.min(this.data.dragItems.length - 1, newIndex));
+
+    if (newIndex !== index) {
+      const newDragItems = [...this.data.dragItems];
+      const [movedItem] = newDragItems.splice(index, 1);
+      newDragItems.splice(newIndex, 0, movedItem);
+
+      newDragItems.forEach((item, i) => {
+        item.y = i * 100;
+      });
+
+      this.setData({ dragItems: newDragItems });
+    } else {
+      const newDragItems = [...this.data.dragItems];
+      newDragItems[index].y = index * 100;
+      this.setData({ dragItems: newDragItems });
+    }
+
+    this.setData({ draggingIndex: -1 });
+  },
+  saveSort() {
+    const reorderedItems = this.data.dragItems.map((di) => {
+      const { y, ...rest } = di;
+      return rest;
+    });
+    this.exitSortMode();
+    this.onSortChange({ detail: reorderedItems });
+  },
+
+  onSortChange(e: { detail: Item[] }) {
+    const originalItems = this.data.items.slice();
+    const reorderedItems = e.detail;
+    const sortItems = reorderedItems.map((item, index) => ({
+      id: item.id,
+      sort: reorderedItems.length - 1 - index,
+    }));
+
+    api
+      .sort(sortItems)
+      .then(() => {
+        this.setData({ items: reorderedItems });
+      })
+      .catch((err: HttpError) => {
+        this.setData({ items: originalItems });
+        Message.error({
+          content: `排序失败：${err.message}`,
+          duration: 5000,
+          offset: [20, 32],
+          context: this,
+        });
+      });
   },
 });

--- a/wechat/miniprogram/pages/totp/index.wxml
+++ b/wechat/miniprogram/pages/totp/index.wxml
@@ -11,12 +11,52 @@
 />
 
 <view class="page">
+  <view class="header" wx:if="{{items.length > 0}}">
+    <view class="header-title">总计 {{items.length}} 个账号</view>
+    <view class="header-action">
+      <t-button wx:if="{{!isSortMode}}" size="small" theme="primary" variant="text" bind:tap="enterSortMode">编辑</t-button>
+      <t-button wx:else size="small" theme="primary" variant="text" bind:tap="saveSort">完成</t-button>
+    </view>
+  </view>
+
   <t-empty wx:if="{{items.length <= 0}}" icon="info-circle-filled" description="暂无数据" />
 
-  <view class="items" wx:if="{{items.length > 0}}">
+  <view class="sort-tip" wx:if="{{isSortMode && items.length > 0}}">
+    <text class="sort-tip-text">长按并拖动可调整顺序</text>
+  </view>
+
+  <movable-area class="items items-sort" wx:if="{{isSortMode && items.length > 0}}" style="height: {{dragItems.length * 100}}px; width: 100%;">
+    <movable-view
+      wx:for="{{ dragItems }}"
+      wx:key="id"
+      y="{{item.y}}"
+      direction="vertical"
+      damping="40"
+      friction="2"
+      out-of-bounds="true"
+      style="width: 100%; height: 100px; z-index: {{draggingIndex === index ? 99 : 1}};"
+      bindchange="onDragChange"
+      bindtouchstart="onDragStart"
+      bindtouchend="onDragEnd"
+      data-index="{{index}}"
+    >
+      <view class="sort-item">
+        <app-totp-item
+          itemId="{{ item.id }}"
+          period="{{ item.config.period }}"
+          issuer="{{ item.issuer }}"
+          username="{{ item.username }}"
+          code="{{ item.code }}"
+        />
+        <view class="sort-mask" />
+      </view>
+    </movable-view>
+  </movable-area>
+
+  <view class="items" wx:if="{{!isSortMode && items.length > 0}}">
     <app-totp-item
       wx:for="{{ items }}"
-      wx:key="unique"
+      wx:key="id"
       wx:for-index="index"
       wx:for-item="item"
       itemId="{{ item.id }}"
@@ -30,5 +70,5 @@
     />
   </view>
 
-  <t-fab icon="add" bind:click="create" aria-label="增加" text="增加"></t-fab>
+  <t-fab wx:if="{{!isSortMode}}" icon="add" bind:click="create" aria-label="增加" text="增加"></t-fab>
 </view>

--- a/wechat/miniprogram/types/totp.d.ts
+++ b/wechat/miniprogram/types/totp.d.ts
@@ -2,6 +2,7 @@ import type { RequestData } from "./http";
 
 export interface Item {
   id: string;
+  sort: number;
   issuer: string;
   username: string;
   code: string;

--- a/wechat/package.json
+++ b/wechat/package.json
@@ -15,12 +15,12 @@
   "author": "me@yansongda.cn",
   "license": "MIT",
   "devDependencies": {
-    "@biomejs/biome": "2.2.4",
-    "miniprogram-api-typings": "^4.1.0",
-    "typescript": "^5.9.3"
+    "@biomejs/biome": "2.4.15",
+    "miniprogram-api-typings": "^5.2.0",
+    "typescript": "^6.0.3"
   },
   "dependencies": {
-    "tdesign-miniprogram": "^1.10.1"
+    "tdesign-miniprogram": "^1.14.0"
   },
   "packageManager": "pnpm@10.17.0+sha512.fce8a3dd29a4ed2ec566fb53efbb04d8c44a0f05bc6f24a73046910fb9c3ce7afa35a0980500668fa3573345bd644644fa98338fa168235c80f4aa17aa17fbef"
 }

--- a/wechat/pnpm-lock.yaml
+++ b/wechat/pnpm-lock.yaml
@@ -9,124 +9,124 @@ importers:
   .:
     dependencies:
       tdesign-miniprogram:
-        specifier: ^1.10.1
-        version: 1.10.1
+        specifier: ^1.14.0
+        version: 1.14.0
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.2.4
-        version: 2.2.4
+        specifier: 2.4.15
+        version: 2.4.15
       miniprogram-api-typings:
-        specifier: ^4.1.0
-        version: 4.1.0
+        specifier: ^5.2.0
+        version: 5.2.0
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
-  '@biomejs/biome@2.2.4':
-    resolution: {integrity: sha512-TBHU5bUy/Ok6m8c0y3pZiuO/BZoY/OcGxoLlrfQof5s8ISVwbVBdFINPQZyFfKwil8XibYWb7JMwnT8wT4WVPg==}
+  '@biomejs/biome@2.4.15':
+    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.2.4':
-    resolution: {integrity: sha512-RJe2uiyaloN4hne4d2+qVj3d3gFJFbmrr5PYtkkjei1O9c+BjGXgpUPVbi8Pl8syumhzJjFsSIYkcLt2VlVLMA==}
+  '@biomejs/cli-darwin-arm64@2.4.15':
+    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.2.4':
-    resolution: {integrity: sha512-cFsdB4ePanVWfTnPVaUX+yr8qV8ifxjBKMkZwN7gKb20qXPxd/PmwqUH8mY5wnM9+U0QwM76CxFyBRJhC9tQwg==}
+  '@biomejs/cli-darwin-x64@2.4.15':
+    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.2.4':
-    resolution: {integrity: sha512-7TNPkMQEWfjvJDaZRSkDCPT/2r5ESFPKx+TEev+I2BXDGIjfCZk2+b88FOhnJNHtksbOZv8ZWnxrA5gyTYhSsQ==}
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
+    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.2.4':
-    resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
+  '@biomejs/cli-linux-arm64@2.4.15':
+    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.2.4':
-    resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
+  '@biomejs/cli-linux-x64-musl@2.4.15':
+    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.2.4':
-    resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
+  '@biomejs/cli-linux-x64@2.4.15':
+    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.2.4':
-    resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
+  '@biomejs/cli-win32-arm64@2.4.15':
+    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.2.4':
-    resolution: {integrity: sha512-3Y4V4zVRarVh/B/eSHczR4LYoSVyv3Dfuvm3cWs5w/HScccS0+Wt/lHOcDTRYeHjQmMYVC3rIRWqyN2EI52+zg==}
+  '@biomejs/cli-win32-x64@2.4.15':
+    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
 
-  miniprogram-api-typings@4.1.0:
-    resolution: {integrity: sha512-4RBsz27nBKyRkVGoNkRaPx24/KeJBw3zaaIlXDR8s/WBh2PbcUAc+q7wLLbp7Qsmb3bLzzUu7tqAti+B06kmjg==}
+  miniprogram-api-typings@5.2.0:
+    resolution: {integrity: sha512-dkel1zG/eAfApabCtZnr9Y69+5z89GtWVPb6aCTvTJ0gu9mk+A0wCwdxlKWReFfXhcvhuonFrfYDwfSnSEkxsA==}
 
-  tdesign-miniprogram@1.10.1:
-    resolution: {integrity: sha512-rKM3JYfJGB+R9G/yp6kGVN0Kc0hKqKoQnpoWm7OVrXNsYM0dlJXwTf+WsLkQtgUyfM20taqNaxXD852Bx7IseQ==}
+  tdesign-miniprogram@1.14.0:
+    resolution: {integrity: sha512-uWzUKebTGjRyQem1rFhD6V/OQ+IpD0S3clFUqeN5IrFxFM59XfNZ/ifTZoVHFhDOG769iI5Gvwfu+BX7kW9vrQ==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
 snapshots:
 
-  '@biomejs/biome@2.2.4':
+  '@biomejs/biome@2.4.15':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.2.4
-      '@biomejs/cli-darwin-x64': 2.2.4
-      '@biomejs/cli-linux-arm64': 2.2.4
-      '@biomejs/cli-linux-arm64-musl': 2.2.4
-      '@biomejs/cli-linux-x64': 2.2.4
-      '@biomejs/cli-linux-x64-musl': 2.2.4
-      '@biomejs/cli-win32-arm64': 2.2.4
-      '@biomejs/cli-win32-x64': 2.2.4
+      '@biomejs/cli-darwin-arm64': 2.4.15
+      '@biomejs/cli-darwin-x64': 2.4.15
+      '@biomejs/cli-linux-arm64': 2.4.15
+      '@biomejs/cli-linux-arm64-musl': 2.4.15
+      '@biomejs/cli-linux-x64': 2.4.15
+      '@biomejs/cli-linux-x64-musl': 2.4.15
+      '@biomejs/cli-win32-arm64': 2.4.15
+      '@biomejs/cli-win32-x64': 2.4.15
 
-  '@biomejs/cli-darwin-arm64@2.2.4':
+  '@biomejs/cli-darwin-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.2.4':
+  '@biomejs/cli-darwin-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.2.4':
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.2.4':
+  '@biomejs/cli-linux-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.2.4':
+  '@biomejs/cli-linux-x64-musl@2.4.15':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.2.4':
+  '@biomejs/cli-linux-x64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.2.4':
+  '@biomejs/cli-win32-arm64@2.4.15':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.2.4':
+  '@biomejs/cli-win32-x64@2.4.15':
     optional: true
 
-  miniprogram-api-typings@4.1.0: {}
+  miniprogram-api-typings@5.2.0: {}
 
-  tdesign-miniprogram@1.10.1: {}
+  tdesign-miniprogram@1.14.0: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}


### PR DESCRIPTION
## 变更摘要

本 PR 仅包含 `wechat/` 目录下的改动，为 TOTP 功能增加拖拽排序交互与主题色调整。

### 提交记录

- **chore(wechat)**: 更新 biome 配置与依赖
- **style(wechat)**: 调整主题色与全局样式
- **feat(wechat)**: TOTP API 增加排序参数与类型定义
- **feat(wechat)**: TOTP 列表拖拽排序交互

### 影响范围

- `wechat/miniprogram/pages/totp/`：TOTP 列表页面交互与样式
- `wechat/miniprogram/api/totp.ts`：API 调用增加排序相关参数
- `wechat/miniprogram/app.scss` 等：全局主题色微调

### 验证建议

1. 进入 TOTP 列表页，验证拖拽排序交互是否正常
2. 验证排序后数据持久化到服务端
3. 检查主题色在各级页面一致性