### PR TITLE
release(wechat): v1.13.0

### DIFF
--- a/wechat/CHANGELOG.md
+++ b/wechat/CHANGELOG.md
@@ -1,5 +1,20 @@
-## v1.12.0
+# Changelog
 
-### added
+本文件遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 规范，版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
-- feat: 增加多平台多应用功能 (#94)
+## [1.13.0] - 2026-05-13
+
+### Added
+
+- TOTP 列表拖拽排序交互 (#131)
+- TOTP API 增加排序参数与类型定义
+
+### Changed
+
+- 调整主题色与全局样式
+
+## [1.12.0] - 2026-05-13
+
+### Added
+
+- 增加多平台多应用功能 (#94)

--- a/wechat/package.json
+++ b/wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yansongda",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "wechat for yansongda",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 版本发布

wechat 前端版本升级至 **v1.13.0**。

### 变更内容

- feat(wechat): TOTP 列表拖拽排序交互 (#131)
- feat(wechat): TOTP API 增加排序参数与类型定义
- style(wechat): 调整主题色与全局样式

### 发布前检查

- [ ] 微信开发者工具编译通过
- [ ] 版本号已更新
- [ ] CHANGELOG 已更新