### PR TITLE
feat: 添加项目专用 agent skills

### DIFF
--- a/.agents/skills/frontend-miniprogram-release/SKILL.md
+++ b/.agents/skills/frontend-miniprogram-release/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: frontend-miniprogram-release
+description: Use when releasing a WeChat mini-program from a monorepo, especially when creating release PRs, bumping versions, updating CHANGELOGs, or creating version tags
+---
+
+# Frontend Mini-Program Release
+
+## Overview
+
+Releasing a mini-program frontend in a monorepo requires careful scope isolation and PR-based workflows. One wrong direct-push to main can require force-push gymnastics.
+
+## When to Use
+
+- Bumping version in `package.json` for a mini-program
+- Creating a release commit with version + CHANGELOG updates
+- Preparing a mini-program for upload to WeChat platform
+- Working in a monorepo where multiple frontends share a single git repository
+
+## Core Rules
+
+### 1. Scope Isolation (CRITICAL)
+
+**Always confirm which directory the user wants to release.**
+
+```bash
+# WRONG: Includes all changes from the branch
+git diff main..HEAD --stat
+
+# RIGHT: Only check changes in the target directory
+git diff main..HEAD -- wechat/
+```
+
+- If the release branch contains changes outside the target directory, **cherry-pick or checkout only the target directory** into a fresh branch from main
+- Never assume "the current branch" equals "only the changes the user cares about"
+
+### 2. Never Direct-Push to Protected Branches
+
+**Version bumps and release commits must go through PR, just like feature code.**
+
+```bash
+# WRONG
+ git commit -m "release: v1.x.x"
+git push origin main
+
+# RIGHT
+git checkout -b release/wechat-v1.x.x
+git commit -m "release(wechat): v1.x.x"
+git push -u origin release/wechat-v1.x.x
+# Then create PR and merge via GitHub
+```
+
+- Even if you have force-push permissions, **don't use them for release commits**
+- If you accidentally pushed to main, use `git revert` + PR instead of force-push to bypass branch protection
+
+### 3. CHANGELOG Format
+
+Follow [Keep a Changelog](https://keepachangelog.com/) (Chinese version supported):
+
+```markdown
+# Changelog
+
+本文件遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 规范。
+
+## [1.13.0] - YYYY-MM-DD
+
+### Added
+- New feature description
+
+### Changed
+- Style or behavior changes
+
+### Fixed
+- Bug fixes
+
+### Removed
+- Deprecated features
+
+## [1.12.0] - YYYY-MM-DD
+```
+
+- Use `[SemVer]` version numbers with brackets
+- Use `### Added / Changed / Fixed / Removed` categories
+- Include PR numbers where applicable: `(#131)`
+- Always add the new version section at the TOP of the file
+
+### 4. Version Bump Checklist
+
+Before creating the release PR:
+
+- [ ] `package.json` version updated
+- [ ] `CHANGELOG.md` updated with new section
+- [ ] Lock file (`pnpm-lock.yaml` / `package-lock.json`) updated if dependencies changed
+- [ ] Only target directory files are included in the commit
+- [ ] Commit message follows repo convention: `release(wechat): v1.x.x`
+
+## Common Mistakes
+
+| Mistake | Why It Happens | Fix |
+|---------|---------------|-----|
+| Direct-pushing release to main | "It's just a version bump" | Treat version bumps like any other code change |
+| Including unrelated directory changes | Assuming branch only has relevant changes | Explicitly filter by target directory |
+| Force-pushing after accidental push | Trying to "clean up" history | Use `git revert` + PR instead |
+| Wrong CHANGELOG format | Copying old inconsistent format | Use Keep a Changelog standard |
+
+## Release Flow
+
+```
+User: "Release wechat"
+  |
+  v
+Check git diff main..HEAD -- wechat/
+  |
+  v
+Create release branch from main
+  |
+  v
+Bump version + update CHANGELOG
+  |
+  v
+Commit and push release branch
+  |
+  v
+Create PR → merge
+  |
+  v
+Pull latest main and create tag: wechat-miniprogram-yansongda/v1.x.x
+  |
+  v
+Push tag to origin
+  |
+  v
+Inform user to upload via WeChat DevTools
+```
+
+## Tag Creation
+
+After the release PR is merged, create a version tag:
+
+```bash
+# Pull latest main first
+git checkout main && git pull origin main
+
+# Create tag
+git tag wechat-miniprogram-yansongda/v1.13.0
+
+# Push tag
+git push origin wechat-miniprogram-yansongda/v1.13.0
+```
+
+- Tag format: `wechat-miniprogram-yansongda/v{semver}`
+- Always pull latest main before tagging to ensure tag points to the merged release commit
+- Push tag immediately after creation
+
+## Platform Upload (Manual Step)
+
+After PR is merged and tag is pushed, the user must manually:
+
+1. Open WeChat DevTools
+2. Compile and verify
+3. Click **Upload** (or 工具 → 上传)
+4. Enter version number and notes
+5. Submit for review on the platform admin page
+
+**Do not attempt automated upload** — platform authentication requires manual login.

--- a/.agents/skills/release-application-rs/SKILL.md
+++ b/.agents/skills/release-application-rs/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: release-application-rs
+description: Use when releasing the application-rs Rust backend workspace, bumping workspace version, updating CHANGELOG, or creating Docker image tags
+---
+
+# Release Application-RS (Rust Backend)
+
+## Overview
+
+The Rust backend in this monorepo is a Cargo workspace that builds a Docker image via GitHub Actions on tag push. It does NOT publish to crates.io (`publish = false`).
+
+**Core principle:** Bump version & changelog → **Create PR** → **User manually merges** → Tag & push (triggers Docker build).
+
+**⚠️ MUST create PR. Never push directly to main.**
+**⚠️ MUST NOT auto-merge the PR. The user must review and merge manually.**
+
+## Prerequisites
+
+- Git working directory clean
+- On `main` branch
+- All Rust CI checks passing (`cargo check`, `cargo fmt --check`, `cargo clippy`)
+
+## The Process
+
+### Step 1: Check Current State
+
+```bash
+# Must run from application-rs/ directory
+cd application-rs
+
+# Current workspace version
+grep '^version = ' Cargo.toml
+
+# Recent tags for application-api
+git tag -l 'application-api/*' | sort -V | tail -5
+
+# Check git status
+git status --short
+git branch --show-current
+```
+
+**Tag format:** `application-api/v<VERSION>` (triggers `.github/workflows/build-image.yml`)
+
+**If dirty:** Stop. Commit or stash changes first.
+
+### Step 2: Bump Version & Update CHANGELOG
+
+**Update `application-rs/Cargo.toml` (workspace root only):**
+
+```toml
+[workspace.package]
+version = "X.Y.Z"  # Bump this
+```
+
+Since all sub-crates use `version.workspace = true`, only the workspace root needs updating. Always run `cargo update` (or any build command) to regenerate `Cargo.lock`, then commit it.
+
+**Update `application-rs/CHANGELOG.md`:**
+
+Follow [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) format:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- New feature description (#PR) ([commit](https://github.com/yansongda/application/commit/abc123))
+
+### Changed
+- Behavior changes (#PR) ([commit](https://github.com/yansongda/application/commit/def456))
+
+### Fixed
+- Bug fixes (#PR) ([commit](https://github.com/yansongda/application/commit/ghi789))
+```
+
+**Format checklist:**
+- [ ] Version: `## [X.Y.Z] - YYYY-MM-DD` (NOT `## vX.Y.Z`)
+- [ ] Section headers capitalized: `### Added`, `### Changed`, `### Fixed`
+- [ ] Each entry has PR number and commit link
+- [ ] New version added at the **TOP** of the file
+
+**Get commits since last release:**
+```bash
+cd application-rs
+git log <PREV_TAG>..HEAD --pretty=format:"- %s ([%h](https://github.com/yansongda/application/commit/%h))"
+```
+
+### Step 3: Verify Rust Code Quality
+
+Before creating PR, ensure all checks pass:
+
+```bash
+cd application-rs
+cargo check --all-features
+cargo fmt --all -- --check
+cargo clippy -- -D warnings
+```
+
+### Step 4: Create PR
+
+```bash
+git checkout -b release/application-rs-vX.Y.Z
+git add application-rs/Cargo.toml application-rs/Cargo.lock application-rs/CHANGELOG.md
+git commit -m "release(application-rs): vX.Y.Z"
+git push origin release/application-rs-vX.Y.Z
+gh pr create --title "release(application-rs): vX.Y.Z" --body "Release application-rs vX.Y.Z"
+```
+
+**Wait for the user to manually review and merge the PR. NEVER auto-merge.**
+
+### Step 5: Tag & Push (After PR Merge)
+
+```bash
+git checkout main && git pull origin main
+
+# Create tag with application-api prefix
+git tag application-api/vX.Y.Z
+git push origin application-api/vX.Y.Z
+```
+
+**⚠️ Tag format must match workflow trigger:**
+- The workflow `.github/workflows/build-image.yml` checks `startsWith(github.ref, 'refs/tags/application-api')`
+- Tag format: `application-api/vX.Y.Z`
+- The workflow converts `/` to `-` for Docker image tags automatically
+
+### Step 6: Verify Docker Build
+
+- GitHub Actions: https://github.com/yansongda/application/actions
+- Check that `build-image.yml` workflow runs successfully
+- Images are pushed to: Aliyun, DockerHub, GitHub Container Registry
+
+## Quick Reference
+
+| Step | Action | Purpose |
+|------|--------|---------|
+| 1. Check | `git status`, `git tag`, check version | Verify clean state |
+| 2. Bump | Edit `Cargo.toml`, `CHANGELOG.md` | Update version and changelog |
+| 3. Verify | `cargo check`, `cargo fmt`, `cargo clippy` | Ensure code quality |
+| 4. PR | Create PR, wait for merge | Review & approve |
+| 5. Tag | `git tag application-api/vX.Y.Z` | Trigger Docker build |
+| 6. Verify | Check GitHub Actions | Confirm image built |
+
+## Common Mistakes
+
+**Wrong tag format**
+- **Problem:** Tag `v1.0.0` won't trigger the workflow
+- **Fix:** Must use `application-api/v1.0.0`
+
+**Bumping individual crate versions**
+- **Problem:** Editing `application-api/Cargo.toml` directly when it uses `version.workspace = true`
+- **Fix:** Only bump workspace root `Cargo.toml`
+
+**Forgetting to run Rust checks**
+- **Problem:** PR fails CI due to `cargo fmt` or `cargo clippy` errors
+- **Fix:** Always run all three checks before creating PR
+
+**Tagging before PR merge**
+- **Problem:** Tag points to pre-merge commit
+- **Fix:** Always `git pull origin main` after merge before tagging
+
+**Direct-pushing to main**
+- **Problem:** Bypasses review and branch protection
+- **Fix:** Always create PR, even for version bumps
+
+## Workspace Structure Reminder
+
+```
+application-rs/
+  Cargo.toml           # Workspace root - bump version here
+  Cargo.lock           # Commit if changed
+  CHANGELOG.md         # Update with new release notes
+  application-api/     # Binary crate (HTTP API)
+  application-database/# Database layer
+  application-kernel/  # Core types, config, errors
+  application-macro/   # Procedural macros
+  application-util/    # HTTP client, 3rd party integrations
+```
+
+All crates share the workspace version via `version.workspace = true`.
+
+## Red Flags
+
+**Never:**
+- Auto-merge the PR (user MUST review manually)
+- Push directly to main
+- Tag before PR merge
+- Skip `cargo fmt` / `cargo clippy` checks
+- Release from dirty working directory
+- Use wrong tag format (`v1.0.0` instead of `application-api/v1.0.0`)
+
+**Always:**
+- Run all Rust checks before PR
+- Update workspace root `Cargo.toml` only
+- Use `application-api/vX.Y.Z` tag format
+- Wait for PR merge before tagging


### PR DESCRIPTION
## 变更摘要

添加两个项目专用的 agent skill，规范前后端发布流程。

### 新增文件

- `.agents/skills/frontend-miniprogram-release/SKILL.md`
  - 微信小程序发布流程规范
  - 范围隔离、禁止直推 main、CHANGELOG 格式、tag 命名规范

- `.agents/skills/release-application-rs/SKILL.md`
  - Rust 后端发布流程规范
  - Workspace 版本管理、Docker 镜像 tag 格式、强制 Rust 代码检查

### 目的

将本次 release 过程中沉淀的经验固化为项目规范，供后续 agent 使用。