### PR TITLE
release(wechat): v1.13.1

### DIFF
--- a/wechat/miniprogram/yansongda/CHANGELOG.md
+++ b/wechat/miniprogram/yansongda/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 本文件遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 规范，版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
+## [1.13.1] - 2026-05-15
+
+### Fixed
+
+- 重写 TOTP 排序交互并预加载 icon 字体 (#136)
+
+### Changed
+
+- 将小程序源码迁移至 miniprogram/yansongda 子目录 (#134)
+
 ## [1.13.0] - 2026-05-13
 
 ### Added

--- a/wechat/miniprogram/yansongda/package.json
+++ b/wechat/miniprogram/yansongda/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yansongda",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "wechat for yansongda",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

发布微信小程序 v1.13.1。

### 变更内容

- **Fixed**: 重写 TOTP 排序交互并预加载 icon 字体 (#136)
- **Changed**: 将小程序源码迁移至 miniprogram/yansongda 子目录 (#134)