### PR TITLE
refactor(skill): 更新 frontend-miniprogram-release skill

### DIFF
--- a/.agents/skills/frontend-miniprogram-release/SKILL.md
+++ b/.agents/skills/frontend-miniprogram-release/SKILL.md
@@ -61,34 +61,71 @@ Follow [Keep a Changelog](https://keepachangelog.com/) (Chinese version supporte
 
 本文件遵循 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/) 规范。
 
-## [1.13.0] - YYYY-MM-DD
+## [1.14.0] - YYYY-MM-DD
 
 ### Added
-- New feature description
-
-### Changed
-- Style or behavior changes
+- New feature description (#101)
 
 ### Fixed
-- Bug fixes
+- Bug fix related to the new feature (#102)
 
-### Removed
-- Deprecated features
+## [1.13.1] - YYYY-MM-DD
 
-## [1.12.0] - YYYY-MM-DD
+### Fixed
+- Bug fix description (#99)
+
+### Changed
+- Refactor or directory migration (#98)
+
+## [1.13.0] - YYYY-MM-DD
 ```
 
 - Use `[SemVer]` version numbers with brackets
 - Use `### Added / Changed / Fixed / Removed` categories
-- Include PR numbers where applicable: `(#131)`
+- Include PR numbers where applicable: `(#101)`
 - Always add the new version section at the TOP of the file
+- When a release contains multiple commit types, list each under its own category
 
-### 4. Version Bump Checklist
+### 4. Version Number Analysis
+
+Before bumping, determine the new version by **analyzing the actual diff**, not just commit messages:
+
+```bash
+# Step 1: List commits since last tag (reference only)
+git log <last-tag>..HEAD --oneline -- <target-dir>/
+
+# Step 2: Inspect each commit's actual changes (THIS is what matters)
+git show --stat <commit> -- <target-dir>/
+
+# Step 3: Review the aggregate diff
+git diff <last-tag>..HEAD -- <target-dir>/
+```
+
+**Commit messages are a hint, diff is the truth.** A `fix:` commit might only touch a comment (no version bump needed), while a `chore:` commit might add a new page (MINOR bump).
+
+Apply [SemVer](https://semver.org/lang/zh-CN/) based on **behavioral impact**:
+
+| What Changed | Version Bump | Example |
+|--------------|-------------|---------|
+| New user-facing feature / new page / new API | **MINOR** | `1.13.0` → `1.14.0` |
+| Bug fix with behavior change | **PATCH** | `1.13.0` → `1.13.1` |
+| Pure refactor / comment update / no behavior change | **No bump** or bundle with other changes | Skip if nothing user-visible changed |
+| Breaking change (removed API, changed response format) | **MAJOR** | `1.13.0` → `2.0.0` |
+
+**Decision flow:**
+
+1. Does any commit add new user-visible functionality? → **MINOR**
+2. Does any commit fix a bug that users experienced? → **PATCH** (if no MINOR)
+3. Are all changes internal refactors / cleanups? → **PATCH** if bundling, otherwise consider skipping release
+4. Does any commit break backward compatibility? → **MAJOR**
+
+### 5. Version Bump Checklist
 
 Before creating the release PR:
 
+- [ ] New version number determined via diff analysis (see §4)
 - [ ] `package.json` version updated
-- [ ] `CHANGELOG.md` updated with new section
+- [ ] `CHANGELOG.md` updated with new section, categorized by change type
 - [ ] Lock file (`pnpm-lock.yaml` / `package-lock.json`) updated if dependencies changed
 - [ ] Only target directory files are included in the commit
 - [ ] Commit message follows repo convention: `release(wechat): v1.x.x`
@@ -101,6 +138,9 @@ Before creating the release PR:
 | Including unrelated directory changes | Assuming branch only has relevant changes | Explicitly filter by target directory |
 | Force-pushing after accidental push | Trying to "clean up" history | Use `git revert` + PR instead |
 | Wrong CHANGELOG format | Copying old inconsistent format | Use Keep a Changelog standard |
+| Auto-merging PR without user consent | Assuming release PRs are safe to auto-merge | Always wait for explicit user confirmation before merging |
+| Bumping version based only on commit messages | `fix:` might be a comment edit; `chore:` might add a new page | Always inspect `git show --stat` and `git diff` to determine actual behavioral impact |
+| Leaving TODO items as `in_progress` while waiting | System continuously prompts for continuation | Mark blocking/waiting tasks as `completed` with a note, or the system will nag |
 
 ## Release Flow
 
@@ -109,6 +149,9 @@ User: "Release wechat"
   |
   v
 Check git diff main..HEAD -- wechat/
+  |
+  v
+Analyze commits → determine SemVer bump (patch/minor/major)
   |
   v
 Create release branch from main
@@ -120,7 +163,10 @@ Bump version + update CHANGELOG
 Commit and push release branch
   |
   v
-Create PR → merge
+Create PR
+  |
+  v
+Merge PR (by user or with explicit permission)
   |
   v
 Pull latest main and create tag: wechat-miniprogram-yansongda/v1.x.x
@@ -141,15 +187,16 @@ After the release PR is merged, create a version tag:
 git checkout main && git pull origin main
 
 # Create tag
-git tag wechat-miniprogram-yansongda/v1.13.0
+git tag wechat-miniprogram-yansongda/v1.x.x
 
 # Push tag
-git push origin wechat-miniprogram-yansongda/v1.13.0
+git push origin wechat-miniprogram-yansongda/v1.x.x
 ```
 
 - Tag format: `wechat-miniprogram-yansongda/v{semver}`
 - Always pull latest main before tagging to ensure tag points to the merged release commit
 - Push tag immediately after creation
+- If `git pull` is not a fast-forward, resolve conflicts first (rare for release branches)
 
 ## Platform Upload (Manual Step)
 


### PR DESCRIPTION
## Summary

基于 v1.13.1 release 实践经验，更新 `frontend-miniprogram-release` skill，提升后续 release 的规范性和准确性。

### 变更内容

1. **CHANGELOG 示例** — 增加多分类示例（同时包含 `Added` / `Fixed` / `Changed`），并明确“一次 release 多个 commit 类型时应分类列出”

2. **新增「Version Number Analysis」章节** — 强调版本号应基于 **diff 分析** 而非仅看 commit message：
   - 给出三步分析流程：`git log` → `git show --stat` → `git diff`
   - 提出原则：**Commit messages are a hint, diff is the truth**
   - 用 SemVer 行为影响表格替代简单的 commit type 映射
   - 新增决策流：先看新功能 → 再看 bugfix → 再看纯重构 → 最后检查破坏性变更

3. **Version Bump Checklist** — 新增“通过 diff analysis 确定版本号”作为首项检查

4. **Release Flow** — 增加「分析 commit 确定 SemVer bump」步骤，并将「Create PR → merge」拆分为「Create PR」→「Merge PR（需用户确认）」

5. **Common Mistakes** — 新增三条：
   - 未经用户同意自动合并 PR
   - 仅基于 commit message 推断版本号
   - 等待时把 TODO 留在 `in_progress` 导致系统反复提醒

6. **Tag Creation** — 示例版本号通用化（`v1.x.x`），并补充 fast-forward 冲突处理提示