### PR TITLE
fix(auth): 微信 access_token 过期语义

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .sisyphus/
 .worktree/
+.worktrees/
+.omo/

--- a/application-rs/application-api/src/response.rs
+++ b/application-rs/application-api/src/response.rs
@@ -172,4 +172,64 @@ mod tests {
             println!("{}", serde_json::to_string_pretty(&response).unwrap());
         }
     }
+
+    #[test]
+    fn test_error_response_access_token_expired_code_1004() {
+        let response =
+            Response::<String>::error(ApiErr(Error::AuthorizationAccessTokenExpired(None)));
+        let json = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(json["code"], 1004);
+        assert!(json["message"].as_str().unwrap().contains("过期"));
+        assert!(json["data"].is_null());
+    }
+
+    #[test]
+    fn test_error_response_refresh_token_invalid_code_1005() {
+        let response =
+            Response::<String>::error(ApiErr(Error::AuthorizationRefreshTokenInvalid(None)));
+        let json = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(json["code"], 1005);
+        assert!(json["message"].as_str().unwrap().contains("不正确"));
+        assert!(json["data"].is_null());
+    }
+
+    #[test]
+    fn test_error_response_refresh_token_expired_code_1006() {
+        let response =
+            Response::<String>::error(ApiErr(Error::AuthorizationRefreshTokenExpired(None)));
+        let json = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(json["code"], 1006);
+        assert!(json["message"].as_str().unwrap().contains("过期"));
+        assert!(json["data"].is_null());
+    }
+
+    #[test]
+    fn test_error_response_auth_codes_are_distinguishable() {
+        let cases: Vec<(Error, u16)> = vec![
+            (Error::AuthorizationAccessTokenExpired(None), 1004),
+            (Error::AuthorizationRefreshTokenInvalid(None), 1005),
+            (Error::AuthorizationRefreshTokenExpired(None), 1006),
+        ];
+
+        for (err, expected_code) in cases {
+            let response = Response::<String>::error(ApiErr(err));
+            let json = serde_json::to_value(&response).unwrap();
+            assert_eq!(json["code"], expected_code);
+            assert!(json["data"].is_null());
+        }
+    }
+
+    #[test]
+    fn test_error_response_access_token_expired_with_custom_message() {
+        let response = Response::<String>::error(ApiErr(Error::AuthorizationAccessTokenExpired(
+            Some("token已失效请重新登录".to_string()),
+        )));
+        let json = serde_json::to_value(&response).unwrap();
+
+        assert_eq!(json["code"], 1004);
+        assert_eq!(json["message"], "token已失效请重新登录");
+    }
 }

--- a/application-rs/application-database/src/account/access_token.rs
+++ b/application-rs/application-database/src/account/access_token.rs
@@ -25,22 +25,20 @@ pub struct AccessToken {
 
 impl AccessToken {
     pub fn is_expired(&self) -> bool {
-        if let Some(expired_at) = self.expired_at {
-            return Local::now() > expired_at;
+        match self.expired_at {
+            Some(expired_at) => Local::now() > expired_at,
+            None => true,
         }
-
-        false
     }
 
     pub fn get_expired_in(&self) -> u32 {
-        // todo： 微信的 access_token 永不过期，后续需要处理
-        if let Some(expired_at) = self.expired_at {
-            let duration = expired_at.signed_duration_since(Local::now());
-
-            return duration.num_seconds() as u32;
+        match self.expired_at {
+            Some(expired_at) => {
+                let duration = expired_at.signed_duration_since(Local::now());
+                duration.num_seconds().try_into().unwrap_or(0)
+            }
+            None => 0,
         }
-
-        G_CONFIG.access_token.expired_in
     }
 }
 
@@ -145,12 +143,7 @@ pub async fn insert(
 ) -> Result<AccessToken> {
     let sql = "insert into account.access_token (user_id, access_token, data, platform, third_id, expired_at) values (?, ?, ?, ?, ?, ?)";
     let access_token = Uuid::now_v7().to_string();
-    let mut expired_at = Some(G_CONFIG.access_token.get_expired_at());
-
-    // todo: 微信的 access_token 永不过期，后续需要处理
-    if Platform::Wechat == *platform {
-        expired_at = None;
-    }
+    let expired_at = Some(G_CONFIG.access_token.get_expired_at());
 
     let pool = Pool::mysql("account")?;
 
@@ -182,12 +175,7 @@ pub async fn update(mut access_token: AccessToken, data: AccessTokenData) -> Res
     let sql =
         "update account.access_token set access_token = ?, data = ?, expired_at = ? where id = ?";
     let access_token_value = Uuid::now_v7().to_string();
-    let mut expired_at = Some(G_CONFIG.access_token.get_expired_at());
-
-    // todo: 微信的 access_token 永不过期，后续需要处理
-    if Platform::Wechat == access_token.platform {
-        expired_at = None;
-    }
+    let expired_at = Some(G_CONFIG.access_token.get_expired_at());
 
     let pool = Pool::mysql("account")?;
 
@@ -250,7 +238,7 @@ mod tests {
     fn test_access_token_is_expired_with_no_expiry() {
         let token = create_test_token(None);
 
-        assert!(!token.is_expired());
+        assert!(token.is_expired());
     }
 
     #[test]
@@ -261,9 +249,16 @@ mod tests {
     }
 
     #[test]
+    fn test_get_expired_in_with_past_expiry() {
+        let token = create_test_token(Some(Local::now() - Duration::seconds(1)));
+
+        assert_eq!(token.get_expired_in(), 0);
+    }
+
+    #[test]
     fn test_get_expired_in_without_expiry() {
         let token = create_test_token(None);
 
-        assert_eq!(token.get_expired_in(), G_CONFIG.access_token.expired_in);
+        assert_eq!(token.get_expired_in(), 0);
     }
 }

--- a/application-rs/application-kernel/src/result.rs
+++ b/application-rs/application-kernel/src/result.rs
@@ -244,4 +244,71 @@ mod tests {
 
         assert_std_error::<Error>();
     }
+
+    #[test]
+    fn test_auth_access_token_expired_maps_to_1004() {
+        let err = Error::AuthorizationAccessTokenExpired(None);
+        let (code, message) = err.get_code_message();
+        assert_eq!(code, 1004);
+        assert!(message.contains("过期"));
+    }
+
+    #[test]
+    fn test_auth_refresh_token_invalid_maps_to_1005() {
+        let err = Error::AuthorizationRefreshTokenInvalid(None);
+        let (code, message) = err.get_code_message();
+        assert_eq!(code, 1005);
+        assert!(message.contains("不正确"));
+    }
+
+    #[test]
+    fn test_auth_refresh_token_expired_maps_to_1006() {
+        let err = Error::AuthorizationRefreshTokenExpired(None);
+        let (code, message) = err.get_code_message();
+        assert_eq!(code, 1006);
+        assert!(message.contains("过期"));
+    }
+
+    #[test]
+    fn test_auth_error_codes_are_distinguishable() {
+        let cases = [
+            (Error::AuthorizationAccessTokenExpired(None), 1004),
+            (Error::AuthorizationRefreshTokenInvalid(None), 1005),
+            (Error::AuthorizationRefreshTokenExpired(None), 1006),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(err.get_code_message().0, expected);
+        }
+    }
+
+    #[test]
+    fn test_auth_access_token_expired_display_format() {
+        let err = Error::AuthorizationAccessTokenExpired(None);
+        let display = err.to_string();
+        assert!(display.starts_with("[1004]"));
+    }
+
+    #[test]
+    fn test_auth_access_token_expired_custom_message() {
+        let err = Error::AuthorizationAccessTokenExpired(Some("自定义过期消息".to_string()));
+        let (code, message) = err.get_code_message();
+        assert_eq!(code, 1004);
+        assert_eq!(message, "自定义过期消息");
+    }
+
+    #[test]
+    fn test_auth_refresh_token_invalid_custom_message() {
+        let err = Error::AuthorizationRefreshTokenInvalid(Some("token被篡改".to_string()));
+        let (code, message) = err.get_code_message();
+        assert_eq!(code, 1005);
+        assert_eq!(message, "token被篡改");
+    }
+
+    #[test]
+    fn test_auth_refresh_token_expired_custom_message() {
+        let err = Error::AuthorizationRefreshTokenExpired(Some("刷新令牌已失效".to_string()));
+        let (code, message) = err.get_code_message();
+        assert_eq!(code, 1006);
+        assert_eq!(message, "刷新令牌已失效");
+    }
 }


### PR DESCRIPTION
## Summary
- 微信 `access_token` 不再永不过期，`expired_at = None` 视为已过期
- `is_expired()` 对 `None` 返回 `true`，`get_expired_in()` 对 `None` 返回 `0`
- 移除 `insert()`/`update()` 中 WeChat 的 `expired_at = None` 特例
- 新增 13 个错误码测试 (1004/1005/1006) 和 token 过期语义测试

## Test Plan
- [x] `cargo test --all-features` (40 tests pass)
- [x] `cargo fmt --all -- --check`
- [x] `cargo check --all-features`