### PR TITLE
fix(miniprogram): 10 bugfix and robustness improvements

### DIFF
--- a/wechat/miniprogram/yansongda/src/components/totp/item.ts
+++ b/wechat/miniprogram/yansongda/src/components/totp/item.ts
@@ -77,7 +77,7 @@ Component({
       this.data.refreshCodeTimeoutIdentity = -1;
 
       clearInterval(this.data.countdownIntervalIdentity);
-      this.data.refreshCodeTimeoutIdentity = -1;
+      this.data.countdownIntervalIdentity = -1;
     },
   },
 });

--- a/wechat/miniprogram/yansongda/src/constant/error.ts
+++ b/wechat/miniprogram/yansongda/src/constant/error.ts
@@ -7,7 +7,10 @@ const CODE = {
   HTTP: 2000,
   // http 内部参数错误
   HTTP_PARAMS: 2001,
-  // 后端业务响应码 - token 过期
+  // 后端业务响应码 - 认证相关
+  BACKEND_AUTH_HEADER_MISSING: 1000,
+  BACKEND_AUTH_TOKEN_INVALID: 1001,
+  BACKEND_AUTH_FORMAT_INVALID: 1002,
   BACKEND_TOKEN_EXPIRED: 1004,
   // http 业务接口 - token
   HTTP_API_ACCESS_TOKEN_LOGIN: 2100,

--- a/wechat/miniprogram/yansongda/src/pages/totp/detail/index.ts
+++ b/wechat/miniprogram/yansongda/src/pages/totp/detail/index.ts
@@ -66,10 +66,10 @@ Page({
 
     switch (e.currentTarget.dataset.type) {
       case "issuer":
-        url = `/pages/totp/edit/issuer?id=${this.data.id}&issuer=${this.response.issuer}`;
+        url = `/pages/totp/edit/issuer?id=${this.data.id}&issuer=${encodeURIComponent(this.response.issuer)}`;
         break;
       case "username":
-        url = `/pages/totp/edit/username?id=${this.data.id}&username=${this.response.username}`;
+        url = `/pages/totp/edit/username?id=${this.data.id}&username=${encodeURIComponent(this.response.username)}`;
         break;
       default:
         break;

--- a/wechat/miniprogram/yansongda/src/pages/user/detail/index.ts
+++ b/wechat/miniprogram/yansongda/src/pages/user/detail/index.ts
@@ -1,8 +1,6 @@
-import { STORAGE } from "@constant/app";
 import { DEFAULT } from "@constant/user";
 import { substr } from "@utils/string";
-import type { User } from "types/user";
-import type { WxGetStorageSuccess } from "types/wechat";
+import user from "@utils/user";
 
 Page({
   data: {
@@ -13,17 +11,13 @@ Page({
     },
   },
   async onShow() {
-    const storage: WxGetStorageSuccess<User> = await wx.getStorage({
-      key: STORAGE.USER,
-    });
+    const u = await user.detail();
 
     this.setData({
       config: {
-        nickname: substr(
-          storage.data.config?.nickname ?? DEFAULT.CONFIG.NICKNAME,
-        ),
-        avatar: storage.data.config?.avatar ?? DEFAULT.CONFIG.AVATAR,
-        slogan: substr(storage.data.config?.slogan ?? DEFAULT.CONFIG.SLOGAN),
+        nickname: substr(u.config?.nickname ?? DEFAULT.CONFIG.NICKNAME),
+        avatar: u.config?.avatar ?? DEFAULT.CONFIG.AVATAR,
+        slogan: substr(u.config?.slogan ?? DEFAULT.CONFIG.SLOGAN),
       },
     });
   },

--- a/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
+++ b/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
@@ -28,27 +28,10 @@ Page({
         quality: 50,
       });
 
-      let localFilePath = res.tempFilePath;
-      if (
-        localFilePath.startsWith("http://") ||
-        localFilePath.startsWith("https://")
-      ) {
-        const downloadRes: { tempFilePath: string } = await new Promise(
-          (resolve, reject) => {
-            wx.downloadFile({
-              url: localFilePath,
-              success: resolve,
-              fail: reject,
-            });
-          },
-        );
-        localFilePath = downloadRes.tempFilePath;
-      }
-
       const fileRes: WxGetFileSystemManagerReadFileSuccess = await new Promise(
         (resolve, reject) => {
           wx.getFileSystemManager().readFile({
-            filePath: localFilePath,
+            filePath: res.tempFilePath,
             encoding: "base64",
             success: resolve,
             fail: reject,
@@ -60,6 +43,7 @@ Page({
         avatar: `data:image/jpeg;base64,${String(fileRes.data)}`,
       });
     } catch (e: unknown) {
+      console.log("头像处理失败", e);
       logger.error("头像处理失败", e);
 
       Toast({

--- a/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
+++ b/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
@@ -43,7 +43,6 @@ Page({
         avatar: `data:image/jpeg;base64,${String(fileRes.data)}`,
       });
     } catch (e: unknown) {
-      console.log("头像处理失败", e);
       logger.error("头像处理失败", e);
 
       Toast({

--- a/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
+++ b/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
@@ -1,16 +1,13 @@
 import api from "@api/user";
-import { STORAGE } from "@constant/app";
 import { DEFAULT } from "@constant/user";
 import error from "@utils/error";
 import logger from "@utils/logger";
 import user from "@utils/user";
 import Message from "tdesign-miniprogram/message/index";
 import Toast from "tdesign-miniprogram/toast/index";
-import type { User } from "types/user";
 import type {
   ChooseAvatarButtonTap,
   WxGetFileSystemManagerReadFileSuccess,
-  WxGetStorageSuccess,
 } from "types/wechat";
 
 Page({
@@ -18,13 +15,9 @@ Page({
     avatar: "",
   },
   async onShow() {
-    const storage: WxGetStorageSuccess<User> = await wx.getStorage({
-      key: STORAGE.USER,
-    });
+    const u = await user.detail();
 
-    this.setData({
-      avatar: storage.data.config?.avatar ?? DEFAULT.CONFIG.AVATAR,
-    });
+    this.setData({ avatar: u.config?.avatar ?? DEFAULT.CONFIG.AVATAR });
   },
   async onChooseAvatar(e: ChooseAvatarButtonTap<unknown, unknown>) {
     try {

--- a/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
+++ b/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
@@ -28,10 +28,27 @@ Page({
         quality: 50,
       });
 
+      let localFilePath = res.tempFilePath;
+      if (
+        localFilePath.startsWith("http://") ||
+        localFilePath.startsWith("https://")
+      ) {
+        const downloadRes: { tempFilePath: string } = await new Promise(
+          (resolve, reject) => {
+            wx.downloadFile({
+              url: localFilePath,
+              success: resolve,
+              fail: reject,
+            });
+          },
+        );
+        localFilePath = downloadRes.tempFilePath;
+      }
+
       const fileRes: WxGetFileSystemManagerReadFileSuccess = await new Promise(
         (resolve, reject) => {
           wx.getFileSystemManager().readFile({
-            filePath: res.tempFilePath,
+            filePath: localFilePath,
             encoding: "base64",
             success: resolve,
             fail: reject,

--- a/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
+++ b/wechat/miniprogram/yansongda/src/pages/user/edit/avatar.ts
@@ -2,6 +2,7 @@ import api from "@api/user";
 import { STORAGE } from "@constant/app";
 import { DEFAULT } from "@constant/user";
 import error from "@utils/error";
+import logger from "@utils/logger";
 import user from "@utils/user";
 import Message from "tdesign-miniprogram/message/index";
 import Toast from "tdesign-miniprogram/toast/index";
@@ -26,22 +27,40 @@ Page({
     });
   },
   async onChooseAvatar(e: ChooseAvatarButtonTap<unknown, unknown>) {
-    await wx.showLoading({ title: "上传中", icon: "loading", mask: true });
+    try {
+      await wx.showLoading({ title: "处理中", icon: "loading", mask: true });
 
-    const res = await wx.compressImage({
-      src: e.detail.avatarUrl.toString(),
-      quality: 50,
-    });
+      const res = await wx.compressImage({
+        src: e.detail.avatarUrl.toString(),
+        quality: 50,
+      });
 
-    wx.getFileSystemManager().readFile({
-      filePath: res.tempFilePath,
-      encoding: "base64",
-      success: async (res: WxGetFileSystemManagerReadFileSuccess) => {
-        this.setData({ avatar: `data:image/jpeg;base64,${res.data}` });
+      const fileRes: WxGetFileSystemManagerReadFileSuccess = await new Promise(
+        (resolve, reject) => {
+          wx.getFileSystemManager().readFile({
+            filePath: res.tempFilePath,
+            encoding: "base64",
+            success: resolve,
+            fail: reject,
+          });
+        },
+      );
 
-        await wx.hideLoading();
-      },
-    });
+      this.setData({
+        avatar: `data:image/jpeg;base64,${String(fileRes.data)}`,
+      });
+    } catch (e: unknown) {
+      logger.error("头像处理失败", e);
+
+      Toast({
+        message: "头像处理失败，请重试",
+        theme: "error",
+        duration: 2000,
+        direction: "column",
+      });
+    } finally {
+      await wx.hideLoading();
+    }
   },
   async submit() {
     Toast({

--- a/wechat/miniprogram/yansongda/src/pages/user/edit/nickname.ts
+++ b/wechat/miniprogram/yansongda/src/pages/user/edit/nickname.ts
@@ -1,12 +1,10 @@
 import api from "@api/user";
-import { STORAGE } from "@constant/app";
 import { DEFAULT } from "@constant/user";
 import error from "@utils/error";
 import user from "@utils/user";
 import Message from "tdesign-miniprogram/message/index";
 import Toast from "tdesign-miniprogram/toast/index";
-import type { User } from "types/user";
-import type { FormSubmit, WxGetStorageSuccess } from "types/wechat";
+import type { FormSubmit } from "types/wechat";
 
 interface FormData {
   nickname: string;
@@ -17,13 +15,9 @@ Page({
     nickname: "",
   },
   async onShow() {
-    const storage: WxGetStorageSuccess<User> = await wx.getStorage({
-      key: STORAGE.USER,
-    });
+    const u = await user.detail();
 
-    this.setData({
-      nickname: storage.data.config?.nickname ?? DEFAULT.CONFIG.NICKNAME,
-    });
+    this.setData({ nickname: u.config?.nickname ?? DEFAULT.CONFIG.NICKNAME });
   },
   async submit(e: FormSubmit<FormData>) {
     Toast({

--- a/wechat/miniprogram/yansongda/src/pages/user/edit/slogan.ts
+++ b/wechat/miniprogram/yansongda/src/pages/user/edit/slogan.ts
@@ -1,12 +1,10 @@
 import api from "@api/user";
-import { STORAGE } from "@constant/app";
 import { DEFAULT } from "@constant/user";
 import error from "@utils/error";
 import user from "@utils/user";
 import Message from "tdesign-miniprogram/message/index";
 import Toast from "tdesign-miniprogram/toast/index";
-import type { User } from "types/user";
-import type { FormSubmit, WxGetStorageSuccess } from "types/wechat";
+import type { FormSubmit } from "types/wechat";
 
 interface FormData {
   slogan: string;
@@ -17,13 +15,9 @@ Page({
     slogan: "",
   },
   async onShow() {
-    const storage: WxGetStorageSuccess<User> = await wx.getStorage({
-      key: STORAGE.USER,
-    });
+    const u = await user.detail();
 
-    this.setData({
-      slogan: storage.data.config?.slogan ?? DEFAULT.CONFIG.SLOGAN,
-    });
+    this.setData({ slogan: u.config?.slogan ?? DEFAULT.CONFIG.SLOGAN });
   },
   async submit(e: FormSubmit<FormData>) {
     Toast({

--- a/wechat/miniprogram/yansongda/src/utils/http.ts
+++ b/wechat/miniprogram/yansongda/src/utils/http.ts
@@ -15,10 +15,6 @@ const AUTH_ENDPOINTS = [
   PATH.VALID,
 ] as readonly string[];
 
-// Symbol cannot be serialized by JSON.stringify or spread-copy, so it never
-// leaks into wx.request data/header even if cloneRequest misses a field.
-const RETRY_MARKER = Symbol("retry");
-
 // Deduplicates concurrent refresh attempts — only one refresh is in flight
 // at any time; subsequent callers await the same promise.
 let inFlightRefresh: Promise<unknown> | null = null;
@@ -62,8 +58,6 @@ const formatHeaders = (request: Request): void => {
 };
 
 // Shallow-clone for mutation: formatUrl/formatHeaders mutate the original.
-// Only copies JSON-safe properties — Symbol keys (like RETRY_MARKER) are
-// intentionally excluded so they stay internal to the request lifecycle.
 const cloneRequest = (req: Request): Request => ({
   url: req.url,
   query: req.query ? { ...req.query } : undefined,
@@ -93,10 +87,11 @@ const handleTokenExpired = async <T>(
   originalRequest: Request,
   code: number,
   message: string,
+  isRetry?: boolean,
 ): Promise<T> => {
-  // Single-retry guard: if the marker is present, we already retried once
-  // after a refresh — reject immediately to prevent an infinite loop.
-  if ((originalRequest as Record<symbol, boolean>)[RETRY_MARKER]) {
+  // Single-retry guard: if we already retried once after a refresh —
+  // reject immediately to prevent an infinite loop.
+  if (isRetry) {
     return Promise.reject(new HttpError(code, message));
   }
 
@@ -112,26 +107,31 @@ const handleTokenExpired = async <T>(
   }
 
   const retryRequest = cloneRequest(originalRequest);
-  // Mark this clone so a second 1004 from the retry is caught by the guard above.
-  (retryRequest as Record<symbol, boolean>)[RETRY_MARKER] = true;
 
-  return request<T>(retryRequest);
+  return request<T>(retryRequest, { isRetry: true });
 };
 
-const request = <T>(req: Request): Promise<T> => {
+const request = <T>(
+  req: Request,
+  opts: { isRetry?: boolean } = {},
+): Promise<T> => {
   const preserved = cloneRequest(req);
 
   formatUrl(req);
   formatHeaders(req);
 
   if (req.isUploadFile) {
-    return wxUpload(req, preserved);
+    return wxUpload(req, preserved, opts);
   }
 
-  return wxRequest(req, preserved);
+  return wxRequest(req, preserved, opts);
 };
 
-const wxRequest = <T>(req: Request, preserved: Request) => {
+const wxRequest = <T>(
+  req: Request,
+  preserved: Request,
+  opts: { isRetry?: boolean } = {},
+) => {
   logger.info(
     "请求接口",
     req.url.indexOf("users/update") === -1 ? req : "用户更新",
@@ -160,6 +160,7 @@ const wxRequest = <T>(req: Request, preserved: Request) => {
             preserved,
             Number(res.data.code),
             res.data.message,
+            opts.isRetry,
           ).then(resolve, reject);
           return;
         }
@@ -181,7 +182,11 @@ const wxRequest = <T>(req: Request, preserved: Request) => {
   });
 };
 
-const wxUpload = <T>(req: Request, preserved: Request) => {
+const wxUpload = <T>(
+  req: Request,
+  preserved: Request,
+  opts: { isRetry?: boolean } = {},
+) => {
   logger.info("请求上传接口", req.url, req.headers);
 
   return new Promise<T>((resolve, reject) => {
@@ -219,6 +224,7 @@ const wxUpload = <T>(req: Request, preserved: Request) => {
             preserved,
             Number(response.code),
             response.message,
+            opts.isRetry,
           ).then(resolve, reject);
           return;
         }

--- a/wechat/miniprogram/yansongda/src/utils/http.ts
+++ b/wechat/miniprogram/yansongda/src/utils/http.ts
@@ -25,8 +25,10 @@ let inFlightRefresh: Promise<unknown> | null = null;
 
 // Login / refresh / valid endpoints must NOT trigger a recursive refresh
 // when they themselves return 1004 — doing so would loop infinitely.
-const isAuthEndpoint = (url: string): boolean =>
-  AUTH_ENDPOINTS.some((ep) => url.includes(ep));
+const isAuthEndpoint = (url: string): boolean => {
+  const pathOnly = url.split("?", 1)[0];
+  return AUTH_ENDPOINTS.some((ep) => pathOnly.endsWith(ep));
+};
 
 const formatUrl = (request: Request): void => {
   if (typeof request.query !== "undefined") {

--- a/wechat/miniprogram/yansongda/src/utils/http.ts
+++ b/wechat/miniprogram/yansongda/src/utils/http.ts
@@ -28,18 +28,19 @@ const isAuthEndpoint = (url: string): boolean => {
 
 const formatUrl = (request: Request): void => {
   if (typeof request.query !== "undefined") {
-    const query = request.query;
+    const params = new URLSearchParams();
 
-    const paramsArray: string[] = [];
+    for (const key of Object.keys(request.query)) {
+      const value = request.query[key];
+      if (value !== null && value !== undefined && value !== "") {
+        params.append(key, String(value));
+      }
+    }
 
-    // biome-ignore lint: no-check
-    Object.keys(request.query).forEach(
-      (key) => query[key] && paramsArray.push(`${key}=${query[key]}`),
-    );
-
-    request.url += `${
-      request.url.search(/\?/) === -1 ? "?" : "&"
-    }${paramsArray.join("&")}`;
+    const qs = params.toString();
+    if (qs) {
+      request.url += `${request.url.search(/\?/) === -1 ? "?" : "&"}${qs}`;
+    }
   }
 
   if (!request.url.startsWith("http")) {

--- a/wechat/miniprogram/yansongda/src/utils/http.ts
+++ b/wechat/miniprogram/yansongda/src/utils/http.ts
@@ -15,6 +15,13 @@ const AUTH_ENDPOINTS = [
   PATH.VALID,
 ] as readonly string[];
 
+const REFRESH_TRIGGER_CODES: readonly number[] = [
+  CODE.BACKEND_AUTH_HEADER_MISSING,
+  CODE.BACKEND_AUTH_TOKEN_INVALID,
+  CODE.BACKEND_AUTH_FORMAT_INVALID,
+  CODE.BACKEND_TOKEN_EXPIRED,
+];
+
 // Deduplicates concurrent refresh attempts — only one refresh is in flight
 // at any time; subsequent callers await the same promise.
 let inFlightRefresh: Promise<unknown> | null = null;
@@ -156,7 +163,7 @@ const wxRequest = <T>(
           return;
         }
 
-        if (Number(res.data.code) === CODE.BACKEND_TOKEN_EXPIRED) {
+        if (REFRESH_TRIGGER_CODES.includes(Number(res.data.code))) {
           handleTokenExpired<T>(
             preserved,
             Number(res.data.code),
@@ -220,7 +227,7 @@ const wxUpload = <T>(
           return;
         }
 
-        if (Number(response.code) === CODE.BACKEND_TOKEN_EXPIRED) {
+        if (REFRESH_TRIGGER_CODES.includes(Number(response.code))) {
           handleTokenExpired<T>(
             preserved,
             Number(response.code),

--- a/wechat/miniprogram/yansongda/src/utils/logger.ts
+++ b/wechat/miniprogram/yansongda/src/utils/logger.ts
@@ -3,15 +3,15 @@ const l = wx.getRealtimeLogManager ? wx.getRealtimeLogManager() : null;
 const logger = {
   // biome-ignore lint: 日志
   info: (...args: any[]) => {
-    l?.info(args);
+    l?.info(...args);
   },
   // biome-ignore lint: 日志
   warning: (...args: any[]) => {
-    l?.warn(args);
+    l?.warn(...args);
   },
   // biome-ignore lint: 日志
   error: (...args: any[]) => {
-    l?.error(args);
+    l?.error(...args);
   },
 };
 

--- a/wechat/miniprogram/yansongda/src/utils/user.ts
+++ b/wechat/miniprogram/yansongda/src/utils/user.ts
@@ -14,7 +14,13 @@ const detail = async (): Promise<User> => {
     /* empty */
   }
 
-  return sync();
+  try {
+    return await sync();
+  } catch (_e) {
+    /* empty */
+  }
+
+  return { phone: "", config: undefined };
 };
 
 const sync = async (): Promise<User> => {


### PR DESCRIPTION
## Summary

10 targeted fixes and improvements across the WeChat miniprogram, addressing timer leaks, HTTP reliability, auth token refresh, URL encoding, and user profile robustness.

## Changes

| Commit | Description |
|--------|-------------|
| `0c398a9` | **fix(totp/item)**: clear `countdownIntervalIdentity` in `clear()` instead of duplicating timeout reset |
| `4da1476` | **fix(logger)**: forward args via spread to `RealtimeLogManager` |
| `12977c2` | **fix(http)**: `isAuthEndpoint` uses path-suffix match to avoid false positives |
| `c4fa2ae` | **fix(http)**: persist single-retry guard via explicit param instead of Symbol marker |
| `53c2bec` | **fix(http)**: percent-encode query params and preserve numeric zero |
| `bf25fa6` | **feat(http)**: refresh access token on 1000/1001/1002 in addition to 1004 |
| `71b1baa` | **fix(totp/detail)**: encode issuer/username when navigating to edit pages |
| `a6f7e4a` | **fix(utils/user)**: graceful default when storage and sync both fail |
| `7d015c6` | **fix(user/edit/avatar)**: handle `readFile` failure and always hide loading |
| `448ffca` | **refactor(pages/user)**: consume `utils/user.detail()` instead of raw `wx.getStorage` |

## Files Changed

- `src/components/totp/item.ts`
- `src/constant/error.ts`
- `src/pages/totp/detail/index.ts`
- `src/pages/user/detail/index.ts`
- `src/pages/user/edit/avatar.ts`
- `src/pages/user/edit/nickname.ts`
- `src/pages/user/edit/slogan.ts`
- `src/utils/http.ts`
- `src/utils/logger.ts`
- `src/utils/user.ts`

## Verification

- [x] `pnpm biome:check` passes
- [x] All changes confined to `wechat/miniprogram/yansongda/src/`
- [x] No breaking changes to existing API contracts