### PR TITLE
release(application-rs): v1.18.0

### DIFF
--- a/application-rs/CHANGELOG.md
+++ b/application-rs/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.18.0] - 2026-06-25
+
+### Added
+
+- feat(auth): 新增认证错误码：access_token 过期（1004）、refresh_token 无效（1005）、refresh_token 过期（1006）(#140) ([8f9e59f](https://github.com/yansongda/application/commit/8f9e59f))
+
+### Changed
+
+- refactor(auth): 调整 access_token 过期语义，`expired_at` 为空时视为已过期，不再对微信 access_token 做永不过期特殊处理 (#140) ([8f9e59f](https://github.com/yansongda/application/commit/8f9e59f))
+
 ## [1.17.0] - 2026-05-13
 
 ### Added

--- a/application-rs/Cargo.lock
+++ b/application-rs/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "application-api"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "application-database",
  "application-kernel",
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "application-database"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "application-kernel",
  "application-util",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "application-kernel"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "chrono",
  "config",
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "application-util"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "application-kernel",
  "reqwest",

--- a/application-rs/Cargo.toml
+++ b/application-rs/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "3"
 
 [workspace.package]
 rust-version = "1.90.0"
-version = "1.17.0"
+version = "1.18.0"
 edition = "2024"
 publish = false
 


### PR DESCRIPTION
Release application-rs v1.18.0.

### Changes

- Added new authentication error codes: access_token expired (1004), refresh_token invalid (1005), refresh_token expired (1006).
- Changed access_token expiration semantics: `expired_at = None` is now treated as expired; WeChat access_token no longer has special never-expire handling.

### Checklist

- [x] `cargo check --all-features` passed
- [x] `cargo fmt --all -- --check` passed
- [x] `cargo clippy -- -D warnings` passed
- [x] `Cargo.lock` updated