### PR TITLE
refactor(skill): 强调 release-application-rs 按实际 diff 决定版本与 changelog

### DIFF
--- a/.agents/skills/release-application-rs/SKILL.md
+++ b/.agents/skills/release-application-rs/SKILL.md
@@ -45,6 +45,37 @@ git branch --show-current
 
 ### Step 2: Bump Version & Update CHANGELOG
 
+**Determine the version bump by analyzing the actual code diff, not just commit messages.**
+
+```bash
+cd application-rs
+
+# Step 1: List commits since last tag (reference only)
+git log <PREV_TAG>..HEAD --oneline
+
+# Step 2: Inspect each commit's actual changes (THIS is what matters)
+git show --stat <commit>
+
+# Step 3: Review the aggregate diff
+git diff <PREV_TAG>..HEAD
+```
+
+**Commit messages are a hint; the diff is the truth.** A `fix:` commit may only touch a comment (no bump needed), while a `chore:` commit may introduce a new API (MINOR bump). Apply SemVer based on **behavioral impact**:
+
+| What Changed | Version Bump | Example |
+|--------------|-------------|---------|
+| New user-facing feature / new API / new binary behavior | **MINOR** | `1.13.0` → `1.14.0` |
+| Bug fix with behavior change | **PATCH** | `1.13.0` → `1.13.1` |
+| Pure refactor / comment update / no behavior change | **No bump** or bundle with other changes | Skip if nothing user-visible changed |
+| Breaking change (removed API, changed config format) | **MAJOR** | `1.13.0` → `2.0.0` |
+
+**Decision flow:**
+
+1. Does any commit add new user-visible functionality? → **MINOR**
+2. Does any commit fix a bug that users experienced? → **PATCH** (if no MINOR)
+3. Are all changes internal refactors / cleanups? → **PATCH** if bundling, otherwise consider skipping release
+4. Does any commit break backward compatibility? → **MAJOR**
+
 **Update `application-rs/Cargo.toml` (workspace root only):**
 
 ```toml
@@ -152,6 +183,10 @@ git push origin application-api/vX.Y.Z
 - **Problem:** PR fails CI due to `cargo fmt` or `cargo clippy` errors
 - **Fix:** Always run all three checks before creating PR
 
+**Bumping version based only on commit messages**
+- **Problem:** A `fix:` commit might only touch a comment (no bump needed), while a `chore:` commit might add a new API (MINOR bump)
+- **Fix:** Always inspect `git show --stat` and `git diff` to determine actual behavioral impact; commit messages are hints, the diff is the truth
+
 **Tagging before PR merge**
 - **Problem:** Tag points to pre-merge commit
 - **Fix:** Always `git pull origin main` after merge before tagging
@@ -185,6 +220,7 @@ All crates share the workspace version via `version.workspace = true`.
 - Skip `cargo fmt` / `cargo clippy` checks
 - Release from dirty working directory
 - Use wrong tag format (`v1.0.0` instead of `application-api/v1.0.0`)
+- Bump version based only on commit messages instead of inspecting the actual diff
 
 **Always:**
 - Run all Rust checks before PR


### PR DESCRIPTION
## 变更原因

`release-application-rs` skill 原先仅通过 `git log` 列出 commit message，容易让使用者仅凭 message 决定版本号和 changelog 分类。

## 变更内容

在 `.agents/skills/release-application-rs/SKILL.md` 中：

- Step 2 开头新增“根据实际代码 diff 而非 commit message 决定版本”的完整指引；
- 提供 `git show --stat` 与 `git diff` 的具体检查命令；
- 补充 SemVer 判定表格与决策流；
- 在 Common Mistakes 新增“仅凭 commit message 定版本”条目；
- 在 Red Flags 新增对应警示。

## 检查项

- [x] 仅修改 skill 文档，无代码行为变更
- [x] frontmatter 与文件结构保持完整
- [x] 与 `frontend-miniprogram-release` skill 的同类规则保持一致
